### PR TITLE
Restructure dashboard to analytics-focused layout

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,7 +1,7 @@
-import { format } from "date-fns";
+import { format, subMonths } from "date-fns";
+import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
 import { getSummary } from "@/app/actions/analysis/get-summary";
 import { getCategories } from "@/app/actions/category/get";
-import { getStores } from "@/app/actions/store/get";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { DashboardView } from "@/components/features/dashboard/dashboard-view";
 
@@ -13,33 +13,38 @@ export default async function DashboardPage({
   searchParams,
 }: DashboardPageProps) {
   const params = await searchParams;
-  const initialPage = 1;
   const now = new Date();
   const defaultMonth = format(now, "yyyy-MM");
   const currentMonth = params.month || defaultMonth;
 
-  const [transactionsData, summaryData, categories, stores] = await Promise.all(
-    [
-      getTransaction(initialPage, currentMonth), // リスト用 (10件)
-      getSummary(currentMonth), // グラフ・集計用 (全件集計)
-      getCategories(), // カテゴリ一覧
-      getStores(), // 店舗一覧
-    ],
-  );
+  // Calculate previous month for MoM comparison
+  const [year, month] = currentMonth.split("-").map(Number);
+  const prevDate = subMonths(new Date(year, month - 1, 1), 1);
+  const previousMonth = format(prevDate, "yyyy-MM");
 
-  const { data: transactions, metadata } = transactionsData;
+  const [recentData, summaryData, prevSummaryData, categories, storeRanking] =
+    await Promise.all([
+      getTransaction(1, currentMonth), // Recent 10 items
+      getSummary(currentMonth),
+      getSummary(previousMonth),
+      getCategories(),
+      getStoreRanking(currentMonth),
+    ]);
+
+  const { data: recentTransactions } = recentData;
   const { summary, categoryStats, monthlyStats } = summaryData;
+  const { summary: previousSummary } = prevSummaryData;
 
   return (
     <DashboardView
       summary={summary}
+      previousSummary={previousSummary}
       monthlyStats={monthlyStats}
       categoryStats={categoryStats}
       currentMonth={currentMonth}
-      transactions={transactions}
-      metadata={metadata}
+      recentTransactions={recentTransactions}
+      storeRanking={storeRanking}
       categories={categories}
-      stores={stores}
     />
   );
 }

--- a/app/(main)/transaction/page.tsx
+++ b/app/(main)/transaction/page.tsx
@@ -16,11 +16,11 @@ export default async function TransactionPage({
   const now = new Date();
   const defaultMonth = format(now, "yyyy-MM");
   const currentMonth = params.month || defaultMonth;
-  // データ取得
+
   const [transactionsData, categories, stores] = await Promise.all([
-    getTransaction(initialPage, currentMonth), // リスト用 (10件)
-    getCategories(), // カテゴリ一覧
-    getStores(), // 店舗一覧
+    getTransaction(initialPage, currentMonth),
+    getCategories(),
+    getStores(),
   ]);
 
   const { data: transactions, metadata } = transactionsData;

--- a/app/actions/analysis/get-store-ranking.ts
+++ b/app/actions/analysis/get-store-ranking.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { format } from "date-fns";
+import { desc, eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { transaction } from "@/db/schema";
+import { auth } from "@/lib/auth";
+
+export async function getStoreRanking(month?: string) {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return [];
+  }
+
+  const currentMonth = month || format(new Date(), "yyyy-MM");
+
+  try {
+    const allTransactions = await db
+      .select({
+        storeName: transaction.storeName,
+        amount: transaction.amount,
+        date: transaction.date,
+        isExpense: transaction.isExpense,
+      })
+      .from(transaction)
+      .where(eq(transaction.userId, session.user.id))
+      .orderBy(desc(transaction.date));
+
+    // Filter to current month + expenses only + has store name
+    const monthlyExpenses = allTransactions.filter(
+      (t) =>
+        format(t.date, "yyyy-MM") === currentMonth &&
+        t.isExpense &&
+        t.storeName,
+    );
+
+    // Aggregate by store name
+    const storeMap = new Map<string, number>();
+    for (const t of monthlyExpenses) {
+      const current = storeMap.get(t.storeName!) || 0;
+      storeMap.set(t.storeName!, current + t.amount);
+    }
+
+    // Sort by total amount descending, take top 5
+    return Array.from(storeMap.entries())
+      .map(([storeName, totalAmount]) => ({ storeName, totalAmount }))
+      .sort((a, b) => b.totalAmount - a.totalAmount)
+      .slice(0, 5);
+  } catch (error) {
+    console.error("Failed to get store ranking:", error);
+    return [];
+  }
+}

--- a/components/features/dashboard/dashboard-view.stories.tsx
+++ b/components/features/dashboard/dashboard-view.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof DashboardView>;
 const mockCategories = [
   {
     id: "1",
-    name: "Food",
+    name: "食費",
     slug: "food",
     type: "expense" as const,
     userId: "user1",
@@ -25,7 +25,7 @@ const mockCategories = [
   },
   {
     id: "2",
-    name: "Salary",
+    name: "給与",
     slug: "salary",
     type: "income" as const,
     userId: "user1",
@@ -35,7 +35,7 @@ const mockCategories = [
   },
   {
     id: "3",
-    name: "Transport",
+    name: "交通費",
     slug: "transport",
     type: "expense" as const,
     userId: "user1",
@@ -45,11 +45,11 @@ const mockCategories = [
   },
 ];
 
-const mockTransactions = [
+const mockRecentTransactions = [
   {
     id: "t1",
     amount: 1200,
-    description: "Lunch",
+    description: "ランチ",
     storeName: "コンビニA",
     category: "food",
     categoryId: "1",
@@ -62,7 +62,7 @@ const mockTransactions = [
   {
     id: "t2",
     amount: 500000,
-    description: "Salary",
+    description: "給与",
     storeName: null,
     category: "salary",
     categoryId: "2",
@@ -72,54 +72,65 @@ const mockTransactions = [
     createdAt: new Date(),
     updatedAt: new Date(),
   },
-];
-
-const mockSummary = {
-  totalIncome: 500000,
-  totalExpense: 1200,
-  balance: 498800,
-  currentMonth: "2024-01",
-  summary: {
-    totalIncome: 500000,
-    totalExpense: 1200,
-    balance: 498800,
+  {
+    id: "t3",
+    amount: 800,
+    description: "コーヒー",
+    storeName: "スタバ",
+    category: "food",
+    categoryId: "1",
+    date: new Date(),
+    userId: "user1",
+    isExpense: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
   },
-  monthlyStats: [],
-  categoryStats: [],
-};
-
-const mockMetadata = {
-  totalCount: 2,
-  totalPages: 1,
-  currentPage: 1,
-  hasNextPage: false,
-  hasPrevPage: false,
-};
+];
 
 export const Default: Story = {
   args: {
-    summary: mockSummary.summary,
+    summary: {
+      totalIncome: 500000,
+      totalExpense: 82000,
+      balance: 418000,
+    },
+    previousSummary: {
+      totalIncome: 480000,
+      totalExpense: 95000,
+      balance: 385000,
+    },
     monthlyStats: [
       { month: "2023-11", income: 450000, expense: 200000 },
       { month: "2023-12", income: 480000, expense: 250000 },
-      { month: "2024-01", income: 500000, expense: 1200 },
+      { month: "2024-01", income: 500000, expense: 82000 },
     ],
     categoryStats: [
-      { category: "food", amount: 1200 },
-      { category: "transport", amount: 5000 },
+      { category: "food", amount: 45000 },
+      { category: "transport", amount: 12000 },
+      { category: "entertainment", amount: 25000 },
     ],
     currentMonth: "2024-01",
-    transactions: mockTransactions,
-    metadata: mockMetadata,
-    categories: mockCategories,
-    stores: [
-      {
-        id: "store-1",
-        name: "コンビニA",
-        userId: "user1",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
+    recentTransactions: mockRecentTransactions,
+    storeRanking: [
+      { storeName: "スーパーA", totalAmount: 18000 },
+      { storeName: "コンビニB", totalAmount: 12000 },
+      { storeName: "スタバ", totalAmount: 8000 },
+      { storeName: "ドラッグストア", totalAmount: 5000 },
+      { storeName: "ユニクロ", totalAmount: 3000 },
     ],
+    categories: mockCategories,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+    previousSummary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+    monthlyStats: [],
+    categoryStats: [],
+    currentMonth: "2024-01",
+    recentTransactions: [],
+    storeRanking: [],
+    categories: mockCategories,
   },
 };

--- a/components/features/dashboard/dashboard-view.tsx
+++ b/components/features/dashboard/dashboard-view.tsx
@@ -1,106 +1,144 @@
 "use client";
 
+import { TrendingDown, TrendingUp } from "lucide-react";
 import { CategoryPie } from "@/components/features/dashboard/charts/category-pie";
 import { MonthlyChart } from "@/components/features/dashboard/charts/monthly-chart";
 import { MonthSelector } from "@/components/features/dashboard/month-selector";
-import { BulkTransactionForm } from "@/components/features/transaction/bulk-transaction-form";
-import { TransactionForm } from "@/components/features/transaction/transaction-form";
-import { TransactionList } from "@/components/features/transaction/transaction-list";
+import { RecentTransactions } from "@/components/features/dashboard/widgets/recent-transactions";
+import { StoreRanking } from "@/components/features/dashboard/widgets/store-ranking";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type {
-  SelectCategory,
-  SelectStore,
-  SelectTransaction,
-} from "@/db/schema";
-import type {
-  CategoryStats,
-  MonthlyStats,
-  SummaryStats,
-  TransactionMetadata,
-} from "@/types";
+import type { SelectCategory, SelectTransaction } from "@/db/schema";
+import type { CategoryStats, MonthlyStats, SummaryStats } from "@/types";
+
+interface StoreRankingItem {
+  storeName: string;
+  totalAmount: number;
+}
 
 interface DashboardViewProps {
   summary: SummaryStats;
+  previousSummary: SummaryStats;
   monthlyStats: MonthlyStats[];
   categoryStats: CategoryStats[];
   currentMonth: string;
-  transactions: SelectTransaction[];
-  metadata: TransactionMetadata;
+  recentTransactions: SelectTransaction[];
+  storeRanking: StoreRankingItem[];
   categories: SelectCategory[];
-  stores: SelectStore[];
+}
+
+function MoMBadge({
+  current,
+  previous,
+}: {
+  current: number;
+  previous: number;
+}) {
+  if (previous === 0) return null;
+  const change = ((current - previous) / previous) * 100;
+  const isUp = change > 0;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 text-xs font-medium ${
+        isUp ? "text-emerald-600" : "text-red-500"
+      }`}
+    >
+      {isUp ? (
+        <TrendingUp className="h-3 w-3" />
+      ) : (
+        <TrendingDown className="h-3 w-3" />
+      )}
+      {Math.abs(change).toFixed(0)}%
+    </span>
+  );
 }
 
 export function DashboardView({
   summary,
+  previousSummary,
   monthlyStats,
   categoryStats,
   currentMonth,
-  transactions,
-  metadata,
+  recentTransactions,
+  storeRanking,
   categories,
-  stores,
 }: DashboardViewProps) {
-  // グラフ用にデータを変換 (Adapter Pattern)
-  // MonthlyChart: { month, income, expense } -> { name, income, expense }
+  // グラフ用にデータを変換
   const barData = monthlyStats.map((stat) => ({
-    name: stat.month, // "2024-01" などを name に入れる
+    name: stat.month,
     income: stat.income,
     expense: stat.expense,
   }));
 
-  // CategoryPie: { category, amount } -> { name, value }
   const rawPieData = categoryStats.map((stat) => {
     const categoryName =
       categories.find((c) => c.id === stat.category || c.slug === stat.category)
         ?.name ??
       stat.category ??
       "不明";
-    return {
-      name: categoryName,
-      value: stat.amount,
-    };
+    return { name: categoryName, value: stat.amount };
   });
 
-  // 名前で集約して重複を排除
   const pieDataMap = new Map<string, number>();
   rawPieData.forEach((item) => {
     const current = pieDataMap.get(item.name) || 0;
     pieDataMap.set(item.name, current + item.value);
   });
-
   const pieData = Array.from(pieDataMap.entries()).map(([name, value]) => ({
     name,
     value,
   }));
 
   return (
-    <main className="container mx-auto p-4 max-w-6xl space-y-8">
+    <main className="container mx-auto p-4 max-w-6xl space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">AssetLens</h1>
+        <h1 className="text-3xl font-bold">ダッシュボード</h1>
         <MonthSelector currentMonth={currentMonth} />
       </div>
 
-      <div className="grid grid-cols-3 gap-4 text-center p-4 bg-muted rounded-lg">
-        <div>
-          <p className="text-sm text-muted-foreground">収入</p>
-          <p className="font-bold text-blue-600">
-            +{summary.totalIncome.toLocaleString()}
-          </p>
-        </div>
-        <div>
-          <p className="text-sm text-muted-foreground">支出</p>
-          <p className="font-bold text-red-600">
-            -{summary.totalExpense.toLocaleString()}
-          </p>
-        </div>
-        <div>
-          <p className="text-sm text-muted-foreground">収支</p>
-          <p className="font-bold">¥{summary.balance.toLocaleString()}</p>
-        </div>
+      {/* サマリーカード (MoM比較付き) */}
+      <div className="grid grid-cols-3 gap-4">
+        <Card>
+          <CardContent className="pt-4 pb-3 text-center">
+            <p className="text-sm text-muted-foreground">収入</p>
+            <p className="text-xl font-bold text-blue-600">
+              +¥{summary.totalIncome.toLocaleString()}
+            </p>
+            <MoMBadge
+              current={summary.totalIncome}
+              previous={previousSummary.totalIncome}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4 pb-3 text-center">
+            <p className="text-sm text-muted-foreground">支出</p>
+            <p className="text-xl font-bold text-red-600">
+              -¥{summary.totalExpense.toLocaleString()}
+            </p>
+            <MoMBadge
+              current={summary.totalExpense}
+              previous={previousSummary.totalExpense}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4 pb-3 text-center">
+            <p className="text-sm text-muted-foreground">収支</p>
+            <p
+              className={`text-xl font-bold ${summary.balance >= 0 ? "text-emerald-600" : "text-red-600"}`}
+            >
+              ¥{summary.balance.toLocaleString()}
+            </p>
+            <MoMBadge
+              current={summary.balance}
+              previous={previousSummary.balance}
+            />
+          </CardContent>
+        </Card>
       </div>
 
-      {/* ダッシュボードエリア */}
+      {/* チャートエリア */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
@@ -121,50 +159,13 @@ export function DashboardView({
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {/* 左側: 入力フォーム (1カラム) */}
-        <div className="md:col-span-1">
-          <Card>
-            <CardHeader>
-              <CardTitle>新規入力</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Tabs defaultValue="single" className="w-full">
-                <TabsList className="grid w-full grid-cols-2 mb-4">
-                  <TabsTrigger value="single">通常入力</TabsTrigger>
-                  <TabsTrigger value="bulk">一括入力</TabsTrigger>
-                </TabsList>
-                <TabsContent value="single">
-                  <TransactionForm categories={categories} stores={stores} />
-                </TabsContent>
-                <TabsContent value="bulk">
-                  <BulkTransactionForm
-                    categories={categories}
-                    stores={stores}
-                  />
-                </TabsContent>
-              </Tabs>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* 右側: 履歴リスト (2カラム) */}
-        <div className="md:col-span-2">
-          <Card>
-            <CardHeader>
-              <CardTitle>直近の履歴</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <TransactionList
-                initialData={transactions}
-                initialMetadata={metadata}
-                currentMonth={currentMonth}
-                categories={categories}
-                stores={stores}
-              />
-            </CardContent>
-          </Card>
-        </div>
+      {/* ウィジェットエリア */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <StoreRanking data={storeRanking} />
+        <RecentTransactions
+          transactions={recentTransactions}
+          currentMonth={currentMonth}
+        />
       </div>
     </main>
   );

--- a/components/features/dashboard/widgets/recent-transactions.stories.tsx
+++ b/components/features/dashboard/widgets/recent-transactions.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RecentTransactions } from "./recent-transactions";
+
+const meta: Meta<typeof RecentTransactions> = {
+  title: "Features/Dashboard/Widgets/RecentTransactions",
+  component: RecentTransactions,
+};
+
+export default meta;
+type Story = StoryObj<typeof RecentTransactions>;
+
+export const Default: Story = {
+  args: {
+    currentMonth: "2024-01",
+    transactions: [
+      {
+        id: "t1",
+        amount: 1200,
+        description: "ランチ",
+        storeName: "コンビニA",
+        category: "food",
+        categoryId: "1",
+        date: new Date(),
+        userId: "user1",
+        isExpense: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "t2",
+        amount: 500000,
+        description: "給与",
+        storeName: null,
+        category: "salary",
+        categoryId: "2",
+        date: new Date(),
+        userId: "user1",
+        isExpense: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "t3",
+        amount: 350,
+        description: "コーヒー",
+        storeName: "スタバ",
+        category: "food",
+        categoryId: "1",
+        date: new Date(),
+        userId: "user1",
+        isExpense: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    currentMonth: "2024-01",
+    transactions: [],
+  },
+};

--- a/components/features/dashboard/widgets/recent-transactions.tsx
+++ b/components/features/dashboard/widgets/recent-transactions.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SelectTransaction } from "@/db/schema";
+
+interface RecentTransactionsProps {
+  transactions: SelectTransaction[];
+  currentMonth: string;
+}
+
+export function RecentTransactions({
+  transactions,
+  currentMonth,
+}: RecentTransactionsProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">📋 直近の取引</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {transactions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            今月の取引データがありません
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {transactions.slice(0, 5).map((tx) => (
+              <div
+                key={tx.id}
+                className="flex items-center justify-between py-1.5 border-b last:border-b-0"
+              >
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="text-sm font-medium truncate">
+                    {tx.storeName || tx.description}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {format(tx.date, "M/d (E)", { locale: ja })}
+                    {tx.storeName && tx.description !== "サブスク" && (
+                      <> · {tx.description}</>
+                    )}
+                  </span>
+                </div>
+                <span
+                  className={`text-sm font-medium tabular-nums whitespace-nowrap ${
+                    tx.isExpense ? "text-red-600" : "text-blue-600"
+                  }`}
+                >
+                  {tx.isExpense ? "-" : "+"}¥{tx.amount.toLocaleString()}
+                </span>
+              </div>
+            ))}
+            <Link
+              href={`/transaction?month=${currentMonth}`}
+              className="block text-sm text-primary hover:underline text-center pt-2"
+            >
+              もっと見る →
+            </Link>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/dashboard/widgets/store-ranking.stories.tsx
+++ b/components/features/dashboard/widgets/store-ranking.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StoreRanking } from "./store-ranking";
+
+const meta: Meta<typeof StoreRanking> = {
+  title: "Features/Dashboard/Widgets/StoreRanking",
+  component: StoreRanking,
+};
+
+export default meta;
+type Story = StoryObj<typeof StoreRanking>;
+
+export const Default: Story = {
+  args: {
+    data: [
+      { storeName: "スーパーA", totalAmount: 18000 },
+      { storeName: "コンビニB", totalAmount: 12000 },
+      { storeName: "スタバ", totalAmount: 8000 },
+      { storeName: "ドラッグストア", totalAmount: 5000 },
+      { storeName: "ユニクロ", totalAmount: 3000 },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { data: [] },
+};

--- a/components/features/dashboard/widgets/store-ranking.tsx
+++ b/components/features/dashboard/widgets/store-ranking.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface StoreRankingItem {
+  storeName: string;
+  totalAmount: number;
+}
+
+interface StoreRankingProps {
+  data: StoreRankingItem[];
+}
+
+export function StoreRanking({ data }: StoreRankingProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">🏪 店舗別ランキング</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            今月の支出データがありません
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const maxAmount = data[0]?.totalAmount ?? 1;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">🏪 店舗別ランキング</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {data.map((item, index) => (
+          <div key={item.storeName} className="space-y-1">
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2">
+                <span className="text-muted-foreground font-mono w-4">
+                  {index + 1}.
+                </span>
+                <span className="font-medium truncate max-w-[140px]">
+                  {item.storeName}
+                </span>
+              </span>
+              <span className="text-muted-foreground tabular-nums">
+                ¥{item.totalAmount.toLocaleString()}
+              </span>
+            </div>
+            <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+              <div
+                className="h-full bg-primary/70 rounded-full transition-all"
+                style={{
+                  width: `${(item.totalAmount / maxAmount) * 100}%`,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/transaction/quick-entry-dialog.tsx
+++ b/components/features/transaction/quick-entry-dialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { getCategories } from "@/app/actions/category/get";
+import { getStores } from "@/app/actions/store/get";
+import { TransactionForm } from "@/components/features/transaction/transaction-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { SelectCategory, SelectStore } from "@/db/schema";
+
+export function QuickEntryDialog() {
+  const [open, setOpen] = useState(false);
+  const [categories, setCategories] = useState<SelectCategory[]>([]);
+  const [stores, setStores] = useState<SelectStore[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (open && !loaded) {
+      Promise.all([getCategories(), getStores()]).then(([cats, sts]) => {
+        setCategories(cats);
+        setStores(sts);
+        setLoaded(true);
+      });
+    }
+  }, [open, loaded]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" className="gap-1.5" id="quick-entry-button">
+          <Plus className="h-4 w-4" />
+          <span className="hidden sm:inline">記録する</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[480px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>取引を記録</DialogTitle>
+        </DialogHeader>
+        {loaded ? (
+          <TransactionForm
+            categories={categories}
+            stores={stores}
+            onSuccess={() => setOpen(false)}
+          />
+        ) : (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/features/transaction/transaction-page-view.tsx
+++ b/components/features/transaction/transaction-page-view.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { BulkTransactionForm } from "@/components/features/transaction/bulk-transaction-form";
+import { TransactionForm } from "@/components/features/transaction/transaction-form";
 import { TransactionList } from "@/components/features/transaction/transaction-list";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
   SelectCategory,
   SelectStore,
@@ -26,20 +30,51 @@ export function TransactionPageView({
   return (
     <main className="container mx-auto max-w-6xl px-4 py-10 space-y-8 min-h-screen">
       <div>
-        <h1 className="text-3xl font-bold">取引一覧</h1>
+        <h1 className="text-3xl font-bold">取引管理</h1>
         <p className="text-muted-foreground mt-2">
-          日々の収支履歴を確認・管理します
+          収支の記録と履歴の確認・管理
         </p>
       </div>
 
-      <TransactionList
-        initialData={transactions}
-        initialMetadata={metadata}
-        currentMonth={currentMonth}
-        categories={categories}
-        stores={stores}
-        showFilters
-      />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* 左側: 入力フォーム (1カラム) */}
+        <div className="md:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>新規入力</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="single" className="w-full">
+                <TabsList className="grid w-full grid-cols-2 mb-4">
+                  <TabsTrigger value="single">通常入力</TabsTrigger>
+                  <TabsTrigger value="bulk">一括入力</TabsTrigger>
+                </TabsList>
+                <TabsContent value="single">
+                  <TransactionForm categories={categories} stores={stores} />
+                </TabsContent>
+                <TabsContent value="bulk">
+                  <BulkTransactionForm
+                    categories={categories}
+                    stores={stores}
+                  />
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 右側: 取引一覧 (2カラム) */}
+        <div className="md:col-span-2">
+          <TransactionList
+            initialData={transactions}
+            initialMetadata={metadata}
+            currentMonth={currentMonth}
+            categories={categories}
+            stores={stores}
+            showFilters
+          />
+        </div>
+      </div>
     </main>
   );
 }

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -3,6 +3,7 @@
 import { LogIn, LogOut, Settings, User, Wallet } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { QuickEntryDialog } from "@/components/features/transaction/quick-entry-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -71,8 +72,9 @@ export function SiteHeader() {
           )}
         </div>
 
-        {/* 右側: ユーザーメニュー */}
+        {/* 右側: クイック入力 + ユーザーメニュー */}
         <div className="flex items-center gap-2">
+          {!isPending && session && <QuickEntryDialog />}
           {isPending ? (
             <Skeleton className="h-8 w-8 rounded-full" />
           ) : session ? (


### PR DESCRIPTION
## Summary
Transform the dashboard from a mixed input/display page into an analytics-focused home screen.

### Changes
- **Dashboard**: Removed TransactionForm, BulkTransactionForm, full TransactionList
- **Dashboard**: Added MoM comparison badges on summary cards (↑↓%)
- **Dashboard**: Added StoreRanking widget (top 5 by spending)
- **Dashboard**: Added RecentTransactions widget (5 items + もっと見る →)
- **Transaction Page**: Added TransactionForm + BulkTransactionForm (1/3 + 2/3 layout)
- **Header**: Added QuickEntryDialog (＋ 記録する button, opens Dialog with TransactionForm)

### Test Results
- 67 files, 178 tests passed
- New Storybook stories: StoreRanking, RecentTransactions, updated DashboardView

Closes #20