### PR TITLE
Add budget management with hybrid model

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { format, subMonths } from "date-fns";
 import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
 import { getSummary } from "@/app/actions/analysis/get-summary";
+import { getBudgets } from "@/app/actions/budget/get";
 import { getCategories } from "@/app/actions/category/get";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { DashboardView } from "@/components/features/dashboard/dashboard-view";
@@ -22,18 +23,36 @@ export default async function DashboardPage({
   const prevDate = subMonths(new Date(year, month - 1, 1), 1);
   const previousMonth = format(prevDate, "yyyy-MM");
 
-  const [recentData, summaryData, prevSummaryData, categories, storeRanking] =
-    await Promise.all([
-      getTransaction(1, currentMonth), // Recent 10 items
-      getSummary(currentMonth),
-      getSummary(previousMonth),
-      getCategories(),
-      getStoreRanking(currentMonth),
-    ]);
+  const [
+    recentData,
+    summaryData,
+    prevSummaryData,
+    categories,
+    storeRanking,
+    budgets,
+  ] = await Promise.all([
+    getTransaction(1, currentMonth),
+    getSummary(currentMonth),
+    getSummary(previousMonth),
+    getCategories(),
+    getStoreRanking(currentMonth),
+    getBudgets(),
+  ]);
 
   const { data: recentTransactions } = recentData;
   const { summary, categoryStats, monthlyStats } = summaryData;
   const { summary: previousSummary } = prevSummaryData;
+
+  // Build categoryExpenses for budget progress from categoryStats
+  const categoryExpenses = categoryStats.map((cs) => {
+    const cat = categories.find(
+      (c) => c.id === cs.category || c.slug === cs.category,
+    );
+    return {
+      categoryId: cat?.id ?? "",
+      amount: cs.amount,
+    };
+  });
 
   return (
     <DashboardView
@@ -45,6 +64,8 @@ export default async function DashboardPage({
       recentTransactions={recentTransactions}
       storeRanking={storeRanking}
       categories={categories}
+      budgets={budgets}
+      categoryExpenses={categoryExpenses}
     />
   );
 }

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,12 +1,23 @@
+import { getBudgets } from "@/app/actions/budget/get";
+import { getCategories } from "@/app/actions/category/get";
 import { getSubscription } from "@/app/actions/subscription/get";
 import { SettingsView } from "@/components/features/settings/settings-view";
 import { requireAuth } from "@/lib/auth/guard";
 
 export default async function SettingsPage() {
-  const [session, subscriptions] = await Promise.all([
+  const [session, subscriptions, budgets, categories] = await Promise.all([
     requireAuth(),
-    getSubscription(), // サブスクリプション一覧を取得
+    getSubscription(),
+    getBudgets(),
+    getCategories(),
   ]);
 
-  return <SettingsView session={session} subscriptions={subscriptions} />;
+  return (
+    <SettingsView
+      session={session}
+      subscriptions={subscriptions}
+      budgets={budgets}
+      categories={categories}
+    />
+  );
 }

--- a/app/actions/budget/delete.test.ts
+++ b/app/actions/budget/delete.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db";
+import { deleteBudget } from "./delete";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/mail/client", () => ({
+  resend: { emails: { send: vi.fn() } },
+}));
+
+describe("deleteBudget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should successfully delete a budget", async () => {
+    const whereMock = vi.fn().mockResolvedValue([]);
+    (db.delete as any).mockReturnValue({ where: whereMock });
+
+    const result = await deleteBudget("budget-123");
+
+    expect(result.success).toBe(true);
+    expect(db.delete).toHaveBeenCalled();
+  });
+
+  it("should return error if not authenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    (auth.api.getSession as any).mockResolvedValueOnce(null);
+
+    const result = await deleteBudget("budget-123");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ログインしてください");
+  });
+
+  it("should handle database errors gracefully", async () => {
+    const whereMock = vi.fn().mockImplementation(() => {
+      throw new Error("DB Error");
+    });
+    (db.delete as any).mockReturnValue({ where: whereMock });
+
+    const result = await deleteBudget("budget-123");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("予算の削除に失敗しました");
+  });
+});

--- a/app/actions/budget/delete.ts
+++ b/app/actions/budget/delete.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { budget } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import type { ActionResult } from "@/types";
+
+export async function deleteBudget(id: string): Promise<ActionResult> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return { success: false, error: "ログインしてください" };
+  }
+
+  try {
+    await db
+      .delete(budget)
+      .where(and(eq(budget.id, id), eq(budget.userId, session.user.id)));
+
+    revalidatePath("/dashboard");
+    revalidatePath("/settings");
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to delete budget:", error);
+    return { success: false, error: "予算の削除に失敗しました" };
+  }
+}

--- a/app/actions/budget/get.ts
+++ b/app/actions/budget/get.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { budget } from "@/db/schema";
+import { auth } from "@/lib/auth";
+
+export async function getBudgets() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return [];
+  }
+
+  try {
+    return await db.query.budget.findMany({
+      where: eq(budget.userId, session.user.id),
+      with: { category: true },
+    });
+  } catch (error) {
+    console.error("Failed to get budgets:", error);
+    return [];
+  }
+}

--- a/app/actions/budget/upsert.test.ts
+++ b/app/actions/budget/upsert.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db";
+import { upsertBudget } from "./upsert";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      budget: {
+        findFirst: vi.fn(),
+      },
+    },
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/mail/client", () => ({
+  resend: { emails: { send: vi.fn() } },
+}));
+
+describe("upsertBudget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create a new overall budget", async () => {
+    (db.query.budget.findFirst as any).mockResolvedValue(null);
+    const valuesMock = vi.fn().mockResolvedValue([]);
+    (db.insert as any).mockReturnValue({ values: valuesMock });
+
+    const result = await upsertBudget({ categoryId: null, amount: 200000 });
+
+    expect(result.success).toBe(true);
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it("should update an existing budget", async () => {
+    (db.query.budget.findFirst as any).mockResolvedValue({
+      id: "budget-1",
+      amount: 100000,
+    });
+    const whereMock = vi.fn().mockResolvedValue([]);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    (db.update as any).mockReturnValue({ set: setMock });
+
+    const result = await upsertBudget({ categoryId: null, amount: 200000 });
+
+    expect(result.success).toBe(true);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("should reject zero or negative amounts", async () => {
+    const result = await upsertBudget({ categoryId: null, amount: 0 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("1円以上");
+  });
+
+  it("should return error if not authenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    (auth.api.getSession as any).mockResolvedValueOnce(null);
+
+    const result = await upsertBudget({ categoryId: null, amount: 200000 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ログインしてください");
+  });
+});

--- a/app/actions/budget/upsert.ts
+++ b/app/actions/budget/upsert.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { and, eq, isNull } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { budget } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import type { ActionResult } from "@/types";
+
+interface UpsertBudgetData {
+  categoryId: string | null; // null = overall budget
+  amount: number;
+}
+
+export async function upsertBudget(
+  data: UpsertBudgetData,
+): Promise<ActionResult> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return { success: false, error: "ログインしてください" };
+  }
+
+  if (data.amount <= 0) {
+    return { success: false, error: "予算は1円以上で設定してください" };
+  }
+
+  try {
+    // Check if budget already exists for this user + category combination
+    const existing = await db.query.budget.findFirst({
+      where: and(
+        eq(budget.userId, session.user.id),
+        data.categoryId
+          ? eq(budget.categoryId, data.categoryId)
+          : isNull(budget.categoryId),
+      ),
+    });
+
+    if (existing) {
+      // Update existing budget
+      await db
+        .update(budget)
+        .set({ amount: data.amount })
+        .where(eq(budget.id, existing.id));
+    } else {
+      // Create new budget
+      await db.insert(budget).values({
+        userId: session.user.id,
+        categoryId: data.categoryId,
+        amount: data.amount,
+      });
+    }
+
+    revalidatePath("/dashboard");
+    revalidatePath("/settings");
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to upsert budget:", error);
+    return { success: false, error: "予算の設定に失敗しました" };
+  }
+}

--- a/components/features/budget/budget-settings.stories.tsx
+++ b/components/features/budget/budget-settings.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BudgetSettings } from "./budget-settings";
+
+const meta: Meta<typeof BudgetSettings> = {
+  title: "Features/Budget/BudgetSettings",
+  component: BudgetSettings,
+};
+
+export default meta;
+type Story = StoryObj<typeof BudgetSettings>;
+
+const mockCategories = [
+  {
+    id: "c1",
+    name: "食費",
+    slug: "food",
+    type: "expense" as const,
+    userId: "user1",
+    sortOrder: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "c2",
+    name: "交通費",
+    slug: "transport",
+    type: "expense" as const,
+    userId: "user1",
+    sortOrder: 2,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "c3",
+    name: "交際費",
+    slug: "social",
+    type: "expense" as const,
+    userId: "user1",
+    sortOrder: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+export const WithBudgets: Story = {
+  args: {
+    budgets: [
+      {
+        id: "b1",
+        userId: "user1",
+        categoryId: null,
+        amount: 200000,
+        category: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "b2",
+        userId: "user1",
+        categoryId: "c1",
+        amount: 50000,
+        category: mockCategories[0],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    categories: mockCategories,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    budgets: [],
+    categories: mockCategories,
+  },
+};

--- a/components/features/budget/budget-settings.tsx
+++ b/components/features/budget/budget-settings.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { deleteBudget } from "@/app/actions/budget/delete";
+import { upsertBudget } from "@/app/actions/budget/upsert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SelectBudget, SelectCategory } from "@/db/schema";
+
+interface BudgetWithCategory extends SelectBudget {
+  category: SelectCategory | null;
+}
+
+interface BudgetSettingsProps {
+  budgets: BudgetWithCategory[];
+  categories: SelectCategory[];
+}
+
+export function BudgetSettings({ budgets, categories }: BudgetSettingsProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editAmount, setEditAmount] = useState("");
+  const [newCategoryId, setNewCategoryId] = useState<string>("overall");
+  const [newAmount, setNewAmount] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const overallBudget = budgets.find((b) => !b.categoryId);
+  const categoryBudgets = budgets.filter((b) => b.categoryId);
+
+  // Categories that already have a budget set
+  const usedCategoryIds = new Set(
+    categoryBudgets.map((b) => b.categoryId).filter(Boolean),
+  );
+  const availableCategories = categories.filter(
+    (c) => c.type === "expense" && !usedCategoryIds.has(c.id),
+  );
+
+  async function handleAdd() {
+    if (!newAmount || Number(newAmount) <= 0) return;
+    setIsSubmitting(true);
+    await upsertBudget({
+      categoryId: newCategoryId === "overall" ? null : newCategoryId,
+      amount: Number(newAmount),
+    });
+    setNewAmount("");
+    setNewCategoryId("overall");
+    setIsSubmitting(false);
+  }
+
+  async function handleUpdate(id: string, categoryId: string | null) {
+    if (!editAmount || Number(editAmount) <= 0) return;
+    setIsSubmitting(true);
+    await upsertBudget({
+      categoryId,
+      amount: Number(editAmount),
+    });
+    setEditingId(null);
+    setEditAmount("");
+    setIsSubmitting(false);
+  }
+
+  async function handleDelete(id: string) {
+    setIsSubmitting(true);
+    await deleteBudget(id);
+    setIsSubmitting(false);
+  }
+
+  function startEditing(b: BudgetWithCategory) {
+    setEditingId(b.id);
+    setEditAmount(b.amount.toString());
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>💰 予算設定</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Overall Budget */}
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium text-muted-foreground">
+            全体の月間予算
+          </h4>
+          {overallBudget ? (
+            <div className="flex items-center gap-2">
+              {editingId === overallBudget.id ? (
+                <>
+                  <Input
+                    type="number"
+                    value={editAmount}
+                    onChange={(e) => setEditAmount(e.target.value)}
+                    className="w-32"
+                    min={1}
+                  />
+                  <span className="text-sm text-muted-foreground">円</span>
+                  <Button
+                    size="sm"
+                    onClick={() => handleUpdate(overallBudget.id, null)}
+                    disabled={isSubmitting}
+                  >
+                    保存
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setEditingId(null)}
+                  >
+                    キャンセル
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <span className="text-lg font-bold">
+                    ¥{overallBudget.amount.toLocaleString()}
+                  </span>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => startEditing(overallBudget)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="text-destructive"
+                    onClick={() => handleDelete(overallBudget.id)}
+                    disabled={isSubmitting}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">未設定</p>
+          )}
+        </div>
+
+        {/* Category Budgets */}
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium text-muted-foreground">
+            カテゴリ別予算
+          </h4>
+          {categoryBudgets.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              カテゴリ別の予算はまだ設定されていません
+            </p>
+          )}
+          {categoryBudgets.map((b) => (
+            <div key={b.id} className="flex items-center gap-2">
+              <span className="text-sm w-20 truncate">
+                {b.category?.name ?? "不明"}
+              </span>
+              {editingId === b.id ? (
+                <>
+                  <Input
+                    type="number"
+                    value={editAmount}
+                    onChange={(e) => setEditAmount(e.target.value)}
+                    className="w-28"
+                    min={1}
+                  />
+                  <span className="text-xs text-muted-foreground">円</span>
+                  <Button
+                    size="sm"
+                    onClick={() => handleUpdate(b.id, b.categoryId)}
+                    disabled={isSubmitting}
+                  >
+                    保存
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setEditingId(null)}
+                  >
+                    ×
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <span className="text-sm font-medium">
+                    ¥{b.amount.toLocaleString()}
+                  </span>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    onClick={() => startEditing(b)}
+                  >
+                    <Pencil className="h-3 w-3" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 text-destructive"
+                    onClick={() => handleDelete(b.id)}
+                    disabled={isSubmitting}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Add New Budget */}
+        <div className="border-t pt-4 space-y-2">
+          <h4 className="text-sm font-medium">予算を追加</h4>
+          <div className="flex items-center gap-2">
+            <Select value={newCategoryId} onValueChange={setNewCategoryId}>
+              <SelectTrigger className="w-36">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {!overallBudget && (
+                  <SelectItem value="overall">全体予算</SelectItem>
+                )}
+                {availableCategories.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              type="number"
+              placeholder="金額"
+              value={newAmount}
+              onChange={(e) => setNewAmount(e.target.value)}
+              className="w-28"
+              min={1}
+            />
+            <span className="text-xs text-muted-foreground">円</span>
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              disabled={isSubmitting || !newAmount}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              追加
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/dashboard/dashboard-view.stories.tsx
+++ b/components/features/dashboard/dashboard-view.stories.tsx
@@ -119,6 +119,30 @@ export const Default: Story = {
       { storeName: "ユニクロ", totalAmount: 3000 },
     ],
     categories: mockCategories,
+    budgets: [
+      {
+        id: "b1",
+        userId: "user1",
+        categoryId: null,
+        amount: 200000,
+        category: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "b2",
+        userId: "user1",
+        categoryId: "1",
+        amount: 50000,
+        category: mockCategories[0],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    categoryExpenses: [
+      { categoryId: "1", amount: 45000 },
+      { categoryId: "3", amount: 12000 },
+    ],
   },
 };
 
@@ -132,5 +156,7 @@ export const Empty: Story = {
     recentTransactions: [],
     storeRanking: [],
     categories: mockCategories,
+    budgets: [],
+    categoryExpenses: [],
   },
 };

--- a/components/features/dashboard/dashboard-view.tsx
+++ b/components/features/dashboard/dashboard-view.tsx
@@ -4,15 +4,24 @@ import { TrendingDown, TrendingUp } from "lucide-react";
 import { CategoryPie } from "@/components/features/dashboard/charts/category-pie";
 import { MonthlyChart } from "@/components/features/dashboard/charts/monthly-chart";
 import { MonthSelector } from "@/components/features/dashboard/month-selector";
+import { BudgetProgress } from "@/components/features/dashboard/widgets/budget-progress";
 import { RecentTransactions } from "@/components/features/dashboard/widgets/recent-transactions";
 import { StoreRanking } from "@/components/features/dashboard/widgets/store-ranking";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { SelectCategory, SelectTransaction } from "@/db/schema";
+import type {
+  SelectBudget,
+  SelectCategory,
+  SelectTransaction,
+} from "@/db/schema";
 import type { CategoryStats, MonthlyStats, SummaryStats } from "@/types";
 
 interface StoreRankingItem {
   storeName: string;
   totalAmount: number;
+}
+
+interface BudgetWithCategory extends SelectBudget {
+  category: SelectCategory | null;
 }
 
 interface DashboardViewProps {
@@ -24,6 +33,8 @@ interface DashboardViewProps {
   recentTransactions: SelectTransaction[];
   storeRanking: StoreRankingItem[];
   categories: SelectCategory[];
+  budgets: BudgetWithCategory[];
+  categoryExpenses: { categoryId: string; amount: number }[];
 }
 
 function MoMBadge({
@@ -62,6 +73,8 @@ export function DashboardView({
   recentTransactions,
   storeRanking,
   categories,
+  budgets,
+  categoryExpenses,
 }: DashboardViewProps) {
   // グラフ用にデータを変換
   const barData = monthlyStats.map((stat) => ({
@@ -158,6 +171,13 @@ export function DashboardView({
           </CardContent>
         </Card>
       </div>
+
+      {/* 予算進捗 */}
+      <BudgetProgress
+        budgets={budgets}
+        totalExpense={summary.totalExpense}
+        categoryExpenses={categoryExpenses}
+      />
 
       {/* ウィジェットエリア */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/components/features/dashboard/widgets/budget-progress.stories.tsx
+++ b/components/features/dashboard/widgets/budget-progress.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BudgetProgress } from "./budget-progress";
+
+const meta: Meta<typeof BudgetProgress> = {
+  title: "Features/Dashboard/Widgets/BudgetProgress",
+  component: BudgetProgress,
+};
+
+export default meta;
+type Story = StoryObj<typeof BudgetProgress>;
+
+export const WithBudgets: Story = {
+  args: {
+    budgets: [
+      {
+        id: "b1",
+        userId: "user1",
+        categoryId: null,
+        amount: 200000,
+        category: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "b2",
+        userId: "user1",
+        categoryId: "cat1",
+        amount: 50000,
+        category: {
+          id: "cat1",
+          name: "食費",
+          slug: "food",
+          type: "expense",
+          userId: "user1",
+          sortOrder: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "b3",
+        userId: "user1",
+        categoryId: "cat2",
+        amount: 15000,
+        category: {
+          id: "cat2",
+          name: "交際費",
+          slug: "social",
+          type: "expense",
+          userId: "user1",
+          sortOrder: 2,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    totalExpense: 145000,
+    categoryExpenses: [
+      { categoryId: "cat1", amount: 42000 },
+      { categoryId: "cat2", amount: 14000 },
+    ],
+  },
+};
+
+export const OverBudget: Story = {
+  args: {
+    budgets: [
+      {
+        id: "b1",
+        userId: "user1",
+        categoryId: null,
+        amount: 100000,
+        category: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    totalExpense: 120000,
+    categoryExpenses: [],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    budgets: [],
+    totalExpense: 50000,
+    categoryExpenses: [],
+  },
+};

--- a/components/features/dashboard/widgets/budget-progress.tsx
+++ b/components/features/dashboard/widgets/budget-progress.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SelectBudget, SelectCategory } from "@/db/schema";
+
+interface BudgetWithCategory extends SelectBudget {
+  category: SelectCategory | null;
+}
+
+interface BudgetProgressProps {
+  budgets: BudgetWithCategory[];
+  totalExpense: number;
+  categoryExpenses: { categoryId: string; amount: number }[];
+}
+
+function ProgressBar({
+  label,
+  spent,
+  limit,
+}: {
+  label: string;
+  spent: number;
+  limit: number;
+}) {
+  const percentage = Math.min((spent / limit) * 100, 100);
+  const color =
+    percentage >= 90
+      ? "bg-red-500"
+      : percentage >= 70
+        ? "bg-yellow-500"
+        : "bg-emerald-500";
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground tabular-nums">
+          ¥{spent.toLocaleString()} / ¥{limit.toLocaleString()}
+        </span>
+      </div>
+      <div className="h-2.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className={`h-full ${color} rounded-full transition-all`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground text-right">
+        {percentage >= 100
+          ? `¥${(spent - limit).toLocaleString()} オーバー`
+          : `残り ¥${(limit - spent).toLocaleString()}`}
+      </p>
+    </div>
+  );
+}
+
+export function BudgetProgress({
+  budgets,
+  totalExpense,
+  categoryExpenses,
+}: BudgetProgressProps) {
+  const overallBudget = budgets.find((b) => !b.categoryId);
+  const categoryBudgets = budgets.filter((b) => b.categoryId);
+
+  if (budgets.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">📊 予算進捗</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            予算が設定されていません。設定ページから予算を追加してください。
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">📊 予算進捗</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Overall Budget */}
+        {overallBudget && (
+          <ProgressBar
+            label="全体予算"
+            spent={totalExpense}
+            limit={overallBudget.amount}
+          />
+        )}
+
+        {/* Category Budgets */}
+        {categoryBudgets.map((b) => {
+          const catExpense =
+            categoryExpenses.find((e) => e.categoryId === b.categoryId)
+              ?.amount ?? 0;
+          return (
+            <ProgressBar
+              key={b.id}
+              label={b.category?.name ?? "不明"}
+              spent={catExpense}
+              limit={b.amount}
+            />
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/settings/settings-view.tsx
+++ b/components/features/settings/settings-view.tsx
@@ -4,6 +4,7 @@ import type { Session } from "better-auth";
 import { AlertTriangle, FileText, Shield, Store } from "lucide-react";
 import { PasskeySettings } from "@/components/features/auth/passkey-settings";
 import { PasswordSettings } from "@/components/features/auth/password-settings";
+import { BudgetSettings } from "@/components/features/budget/budget-settings";
 import { DeleteAccountButton } from "@/components/features/settings/delete-account-button";
 import { ExportButton } from "@/components/features/settings/export-button";
 import { ImportButton } from "@/components/features/settings/import-button";
@@ -18,9 +19,13 @@ import {
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { subscription } from "@/db/schema";
+import type { SelectBudget, SelectCategory, subscription } from "@/db/schema";
 
 type SelectSubscription = typeof subscription.$inferSelect;
+
+interface BudgetWithCategory extends SelectBudget {
+  category: SelectCategory | null;
+}
 
 // ... existing imports ...
 
@@ -33,9 +38,16 @@ interface SettingsViewProps {
     };
   };
   subscriptions: SelectSubscription[];
+  budgets: BudgetWithCategory[];
+  categories: SelectCategory[];
 }
 
-export function SettingsView({ session, subscriptions }: SettingsViewProps) {
+export function SettingsView({
+  session,
+  subscriptions,
+  budgets,
+  categories,
+}: SettingsViewProps) {
   return (
     <main className="container max-w-5xl px-4 py-10 space-y-8 mx-auto min-h-screen">
       <div>
@@ -48,10 +60,11 @@ export function SettingsView({ session, subscriptions }: SettingsViewProps) {
       <Separator />
 
       <Tabs defaultValue="account" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-3 lg:w-150">
+        <TabsList className="grid w-full grid-cols-4 lg:w-150">
           <TabsTrigger value="account">アカウント</TabsTrigger>
+          <TabsTrigger value="budget">予算</TabsTrigger>
           <TabsTrigger value="data">データ管理</TabsTrigger>
-          <TabsTrigger value="subscription">サブスクリプション</TabsTrigger>
+          <TabsTrigger value="subscription">サブスク</TabsTrigger>
         </TabsList>
 
         <TabsContent value="account" className="space-y-6">
@@ -92,6 +105,11 @@ export function SettingsView({ session, subscriptions }: SettingsViewProps) {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        {/* --- タブ: 予算管理 --- */}
+        <TabsContent value="budget" className="space-y-6">
+          <BudgetSettings budgets={budgets} categories={categories} />
         </TabsContent>
 
         {/* --- タブ: データ管理 --- */}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -281,3 +281,38 @@ export const passkeyRelations = relations(passkey, ({ one }) => ({
     references: [user.id],
   }),
 }));
+
+// Budget: hybrid model
+// categoryId = null → overall monthly budget (parent)
+// categoryId = uuid → per-category budget (child)
+export const budget = pgTable("budget", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  categoryId: uuid("category_id").references(() => category.id, {
+    onDelete: "cascade",
+  }),
+  amount: integer("amount").notNull(),
+  createdAt: timestamp("created_at", { precision: 0, withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { precision: 0, withTimezone: true })
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export type SelectBudget = typeof budget.$inferSelect;
+export type InsertBudget = typeof budget.$inferInsert;
+
+export const budgetRelations = relations(budget, ({ one }) => ({
+  user: one(user, {
+    fields: [budget.userId],
+    references: [user.id],
+  }),
+  category: one(category, {
+    fields: [budget.categoryId],
+    references: [category.id],
+  }),
+}));

--- a/drizzle/0011_faulty_zarda.sql
+++ b/drizzle/0011_faulty_zarda.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "budget" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"category_id" uuid,
+	"amount" integer NOT NULL,
+	"created_at" timestamp (0) with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "budget" ADD CONSTRAINT "budget_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "budget" ADD CONSTRAINT "budget_category_id_category_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."category"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,973 @@
+{
+  "id": "45878b81-bfcf-4ef6-82b3-1cbc7e7c5082",
+  "prevId": "601fa0ed-17b8-4667-a2b1-d527576a1344",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget": {
+      "name": "budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_user_id_user_id_fk": {
+          "name": "budget_user_id_user_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_category_id_category_id_fk": {
+          "name": "budget_category_id_category_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'expense'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_userId_user_id_fk": {
+          "name": "category_userId_user_id_fk",
+          "tableFrom": "category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store": {
+      "name": "store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_userId_idx": {
+          "name": "store_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JPY'"
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_payment_date": {
+          "name": "next_payment_date",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_userId_idx": {
+          "name": "subscription_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_userId_idx": {
+          "name": "transactions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_user_id_user_id_fk": {
+          "name": "transaction_user_id_user_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_category_id_category_id_fk": {
+          "name": "transaction_category_id_category_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1774748629712,
       "tag": "0010_useful_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1774776656587,
+      "tag": "0011_faulty_zarda",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add budget management feature with a hybrid model: overall monthly budget + optional per-category budgets.

### New Features
- **DB Schema**: `budget` table with hybrid design (categoryId=null → overall, categoryId=uuid → per-category)
- **Server Actions**: `getBudgets`, `upsertBudget`, `deleteBudget`
- **Dashboard Widget**: BudgetProgress with color-coded progress bars (green <70%, yellow 70-90%, red >90%)
- **Settings Tab**: 予算 tab with add/edit/delete for overall and per-category budgets

### Test Results
- 71 files, 190 tests passed (+12 new tests)
- New Storybook stories: BudgetProgress (3 variants), BudgetSettings (2 variants)

Closes #21