### PR TITLE
Fix CI: add Playwright browser install for Storybook tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npx vitest run
 
   e2e-tests:


### PR DESCRIPTION
## Summary
Add `npx playwright install --with-deps chromium` step before `npx vitest run` in CI workflow. Storybook tests use Vitest browser mode which requires Playwright browsers to be installed.

### Root Cause
CI ran `npm ci` which installs Playwright as a dependency, but never downloaded the actual browser binaries needed to launch Chromium for Storybook browser tests.

Closes #52