### PR TITLE
Fix: Dashboard crashes when previousSummary is undefined

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -41,7 +41,9 @@ export default async function DashboardPage({
 
   const { data: recentTransactions } = recentData;
   const { summary, categoryStats, monthlyStats } = summaryData;
-  const { summary: previousSummary } = prevSummaryData;
+  const { summary: previousSummary } = prevSummaryData ?? {
+    summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+  };
 
   // Build categoryExpenses for budget progress from categoryStats
   const categoryExpenses = categoryStats.map((cs) => {

--- a/components/features/dashboard/dashboard-view.tsx
+++ b/components/features/dashboard/dashboard-view.tsx
@@ -66,7 +66,7 @@ function MoMBadge({
 
 export function DashboardView({
   summary,
-  previousSummary,
+  previousSummary = { totalIncome: 0, totalExpense: 0, balance: 0 },
   monthlyStats,
   categoryStats,
   currentMonth,


### PR DESCRIPTION
## Summary
Add default fallback `{ totalIncome: 0, totalExpense: 0, balance: 0 }` for `previousSummary` in both the dashboard page and the DashboardView component.

### Root Cause
`getSummary(previousMonth)` can return undefined `summary` when there is no data for the previous month. The MoM comparison badge tried to access `previousSummary.totalIncome` without a null check.

### Fix
- **page.tsx**: Fallback via nullish coalescing on destructure
- **dashboard-view.tsx**: Default parameter value on `previousSummary` prop

Closes #54