### PR TITLE
Fix Issue closing policy in workflows

### DIFF
--- a/.agents/workflows/feature-development.md
+++ b/.agents/workflows/feature-development.md
@@ -9,7 +9,7 @@ description: How to implement a new feature from planning to merge
 > - ALL work (features, fixes, docs, chores) MUST be done on a dedicated branch first.
 > - Branch types: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`
 > - Even single-file changes (docs, config) require a branch.
-> - **NEVER manually close Issues**. Issues are closed automatically when the PR with `Closes #<number>` is merged.
+> - **Issue closing**: Feature PRs (→ `develop`) should reference Issues (e.g. `Relates to #<number>`) for traceability. **Release PRs (`release/vX.Y.Z` → `main`)** must include `Closes #<number>` for all Issues resolved in that release — GitHub auto-closes Issues only on merge to the default branch (`main`).
 > - **Language**: All Issues, PRs, commit messages, and CHANGELOG entries MUST be written in **English**. UI text and comments in code may be in Japanese.
 
 ## 1. Create Issue
@@ -69,7 +69,9 @@ npx playwright test --project=chromium --workers=1
 - Quality checklist (Step 5) is satisfied
 
 Push the branch and create a PR targeting `develop`.
-**Include `Closes #<issue-number>` in the PR body** to auto-close the Issue on merge.
+**Include `Relates to #<issue-number>` in the PR body** for traceability (do NOT use `Closes` here — it won't work on non-default branches).
+
+> ⚠️ `Closes #` only auto-closes Issues on merge to `main`. All `Closes #` references should be consolidated in the **release PR** (see release workflow).
 
 ```bash
 git push origin <branch-name>

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -57,6 +57,8 @@ gh pr create --base main --head release/v<VERSION> --title "Release v<VERSION>" 
 ```
 PR description should include: New Features, Bug Fixes, Improvements, Test Results, Migration Notes.
 
+> **⚠️ IMPORTANT**: Include `Closes #<number>` for **every Issue** resolved in this release. This is the only place where Issues get auto-closed (GitHub only auto-closes on merge to the default branch `main`).
+
 ## 6. After PR Merge — Tag & Release
 ```bash
 git checkout main && git pull origin main
@@ -74,8 +76,12 @@ git branch -d release/v<VERSION>
 git push origin --delete release/v<VERSION>
 ```
 
-## 8. Close Related Issues
+## 8. Verify Issues Closed
+After the release PR is merged, verify that all referenced Issues were auto-closed:
+```bash
+gh issue list --state open --json number,title
+```
+If any Issues that should be closed are still open, it means they were not referenced with `Closes #` in the release PR. Fix by manually closing:
 ```bash
 gh issue close <NUMBER> --reason completed
 ```
-Or reference `Closes #<NUMBER>` in the PR body for auto-close on merge.


### PR DESCRIPTION
## Summary
Updated both feature-development.md and release.md:
- Feature PRs → develop: use `Relates to #` for traceability only
- Release PRs (release/vX.Y.Z → main): use `Closes #` for auto-close on merge
- Release step 8: verify Issues closed instead of manual close