### PR TITLE
Fix auth page UX and landing page layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default async function LandingPage() {
 
           <h1 className="text-4xl font-extrabold tracking-tight lg:text-6xl bg-clip-text text-transparent bg-linear-to-r from-foreground to-foreground/70">
             資産管理を、
-            <br className="md:hidden" />
+            <br />
             もっとシンプルに。
           </h1>
 

--- a/components/features/auth/guest-view.tsx
+++ b/components/features/auth/guest-view.tsx
@@ -36,6 +36,7 @@ export function GuestView() {
           <Button
             onClick={handlePasskeySignIn}
             disabled={isLoading}
+            variant="outline"
             className="w-full h-12 text-base font-semibold shadow-sm"
             size="lg"
           >

--- a/components/features/auth/sign-in-form.tsx
+++ b/components/features/auth/sign-in-form.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -65,15 +64,15 @@ export function SignInForm() {
           name="password"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>パスワード</FormLabel>
-              <FormDescription>
+              <div className="flex items-center justify-between">
+                <FormLabel>パスワード</FormLabel>
                 <Link
                   href="/forget-password"
-                  className="text-sm text-muted-foreground hover:underline"
+                  className="text-xs text-muted-foreground hover:underline"
                 >
                   パスワードを忘れた場合
                 </Link>
-              </FormDescription>
+              </div>
               <FormControl>
                 <Input type="password" {...field} />
               </FormControl>
@@ -86,7 +85,6 @@ export function SignInForm() {
           type="submit"
           className="w-full"
           disabled={isLoading}
-          variant="secondary"
         >
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           ログイン

--- a/components/features/auth/sign-up-form.tsx
+++ b/components/features/auth/sign-up-form.tsx
@@ -111,7 +111,6 @@ export function SignUpForm() {
           type="submit"
           className="w-full"
           disabled={isLoading}
-          variant="secondary"
         >
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           アカウント作成

--- a/components/layouts/site-footer.tsx
+++ b/components/layouts/site-footer.tsx
@@ -1,13 +1,28 @@
+import Link from "next/link";
 import { Wallet } from "lucide-react";
 
 export function SiteFooter() {
   return (
     <footer className="py-8 border-t bg-muted/30">
-      <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-muted-foreground  max-w-6xl px-4">
+      <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-muted-foreground max-w-6xl px-4">
         <div className="flex items-center gap-2 font-semibold">
           <Wallet className="h-5 w-5" />
           AssetLens
         </div>
+        <nav
+          className="flex items-center gap-4 text-xs"
+          aria-label="フッターナビゲーション"
+        >
+          <Link href="/terms" className="hover:underline hover:text-foreground transition-colors">
+            利用規約
+          </Link>
+          <Link href="/privacy" className="hover:underline hover:text-foreground transition-colors">
+            プライバシーポリシー
+          </Link>
+          <Link href="/contact" className="hover:underline hover:text-foreground transition-colors">
+            お問い合わせ
+          </Link>
+        </nav>
         <p>© 2026 AssetLens. All rights reserved.</p>
       </div>
     </footer>

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -131,13 +131,16 @@ export function SiteHeader() {
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
-            // ▼ 未ログイン: ログインボタン
-            <Button asChild variant="default" size="sm">
-              <Link href="/login">
-                <LogIn className="mr-2 h-4 w-4" />
-                ログイン
-              </Link>
-            </Button>
+            // ▼ 未ログイン: ログインボタン（auth ページでは非表示）
+            !pathname.startsWith("/login") &&
+            !pathname.startsWith("/forget-password") && (
+              <Button asChild variant="default" size="sm">
+                <Link href="/login">
+                  <LogIn className="mr-2 h-4 w-4" />
+                  ログイン
+                </Link>
+              </Button>
+            )
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
Batch fix for Tier 1 quick wins focused on landing page and auth page UX.

### Changes
- **#58**: Fix hero title awkward line break — always break after '資産管理を、'
- **#59**: Fix button hierarchy — form submit button is now primary, Passkey button is outline
- **#60**: Hide redundant header login button when already on auth pages
- **#61**: Move forgot password link inline with password label (right-aligned)
- **#65**: Add footer navigation links (利用規約, プライバシーポリシー, お問い合わせ)

Relates to #58, #59, #60, #61, #65