### PR TITLE
Add error boundary and custom 404 page

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { AlertTriangle, Home, RotateCcw } from "lucide-react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Application error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center">
+          <AlertTriangle className="h-8 w-8 text-destructive" />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">
+            エラーが発生しました
+          </h1>
+          <p className="text-muted-foreground">
+            ページの読み込み中に問題が発生しました。再度お試しください。
+          </p>
+        </div>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <Button onClick={() => reset()} variant="default">
+            <RotateCcw className="mr-2 h-4 w-4" />
+            再試行
+          </Button>
+          <Button variant="outline" asChild>
+            <a href="/">
+              <Home className="mr-2 h-4 w-4" />
+              トップページへ
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { AlertTriangle, Home, RotateCcw } from "lucide-react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body className="flex min-h-screen items-center justify-center bg-background p-4">
+        <div className="text-center space-y-6 max-w-md">
+          <div className="mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center">
+            <AlertTriangle className="h-8 w-8 text-destructive" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold tracking-tight">
+              予期せぬエラーが発生しました
+            </h1>
+            <p className="text-muted-foreground">
+              申し訳ありません。アプリケーションに問題が発生しました。
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button onClick={() => reset()} variant="default">
+              <RotateCcw className="mr-2 h-4 w-4" />
+              再読み込み
+            </Button>
+            <Button variant="outline" asChild>
+              <a href="/">
+                <Home className="mr-2 h-4 w-4" />
+                トップページへ
+              </a>
+            </Button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,30 @@
+import { FileQuestion, Home } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="mx-auto w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+          <FileQuestion className="h-8 w-8 text-muted-foreground" />
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-4xl font-bold tracking-tight">404</h1>
+          <p className="text-lg text-muted-foreground">
+            ページが見つかりませんでした
+          </p>
+          <p className="text-sm text-muted-foreground">
+            URLが正しいかご確認ください。
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/">
+            <Home className="mr-2 h-4 w-4" />
+            トップページへ
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add user-friendly error handling pages to prevent blank screens on errors.

### Changes
- **global-error.tsx**: Catches unrecoverable errors outside the layout
- **error.tsx**: Route-level error boundary with retry button
- **not-found.tsx**: Custom 404 page

All pages include a clear error message in Japanese, a retry/home action, and consistent styling.

Relates to #73