### PR TITLE
Add page-specific loading skeletons

### DIFF
--- a/app/(main)/dashboard/loading.tsx
+++ b/app/(main)/dashboard/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="container mx-auto max-w-6xl px-4 md:px-8 py-10 space-y-8">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-10 w-36 rounded-md" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Skeleton className="h-28 rounded-xl" />
+        <Skeleton className="h-28 rounded-xl" />
+        <Skeleton className="h-28 rounded-xl" />
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Skeleton className="h-72 rounded-xl" />
+        <Skeleton className="h-72 rounded-xl" />
+      </div>
+
+      <Skeleton className="h-64 rounded-xl" />
+    </div>
+  );
+}

--- a/app/(main)/transaction/loading.tsx
+++ b/app/(main)/transaction/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TransactionLoading() {
+  return (
+    <div className="container mx-auto max-w-6xl px-4 md:px-8 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-40" />
+        <div className="flex gap-2">
+          <Skeleton className="h-10 w-36 rounded-md" />
+          <Skeleton className="h-10 w-28 rounded-md" />
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Skeleton className="h-10 w-64 rounded-md" />
+        <Skeleton className="h-10 w-32 rounded-md" />
+      </div>
+
+      <div className="space-y-3">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={`tx-row-${i}`} className="h-14 w-full rounded-lg" />
+        ))}
+      </div>
+
+      <div className="flex justify-center">
+        <Skeleton className="h-10 w-48 rounded-md" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add dedicated loading skeletons for dashboard and transaction pages to replace the generic fallback.

### Changes
- **dashboard/loading.tsx**: 3 summary cards + 2 chart areas + table skeleton
- **transaction/loading.tsx**: Search bar + filter + 8 row items + pagination skeleton

Relates to #40