### PR TITLE
Fix biome lint errors

### DIFF
--- a/app/(main)/transaction/loading.tsx
+++ b/app/(main)/transaction/loading.tsx
@@ -17,9 +17,14 @@ export default function TransactionLoading() {
       </div>
 
       <div className="space-y-3">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <Skeleton key={`tx-row-${i}`} className="h-14 w-full rounded-lg" />
-        ))}
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
       </div>
 
       <div className="flex justify-center">

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, Home, RotateCcw } from "lucide-react";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 
-export default function Error({
+export default function ErrorPage({
   error,
   reset,
 }: {

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -37,7 +37,10 @@ export function SiteHeader() {
           </Link>
           {/* ログイン済み */}
           {!isPending && session && (
-            <nav aria-label="メインナビゲーション" className="hidden md:flex items-center gap-4 text-sm font-medium">
+            <nav
+              aria-label="メインナビゲーション"
+              className="hidden md:flex items-center gap-4 text-sm font-medium"
+            >
               <Link
                 href="/dashboard"
                 className={


### PR DESCRIPTION
## Summary
Fix 3 biome errors that caused CI failure:
- Rename `Error` → `ErrorPage` to avoid shadowing global
- Replace array index key with static skeleton elements
- Apply biome formatter to site-header.tsx