### PR TITLE
Add confirmation dialogs for destructive actions

### DIFF
--- a/components/features/auth/passkey-settings.tsx
+++ b/components/features/auth/passkey-settings.tsx
@@ -7,6 +7,17 @@ import { Fingerprint, Loader2, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { UAParser } from "ua-parser-js";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -69,10 +80,7 @@ export function PasskeySettings() {
 
   // 削除処理
   const handleDeletePasskey = async (id: string) => {
-    if (!confirm("このPasskeyを削除してもよろしいですか？")) return;
-
     await deletePasskey({ passkeyId: id });
-    // 削除成功したらリストから除外（再取得より高速にUI反映するため）
     setPasskeys((prev) => prev.filter((pk) => pk.id !== id));
 
     toast.info("アプリからの削除が完了しました", {
@@ -135,15 +143,38 @@ export function PasskeySettings() {
                     })}
                   </TableCell>
                   <TableCell className="text-right">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDeletePasskey(pk.id)}
-                      disabled={isLoading}
-                      className="text-muted-foreground hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={isLoading}
+                          className="text-muted-foreground hover:text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Passkeyを削除しますか？
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            「{pk.name || "名称未設定"}
+                            」を削除します。端末側の設定は別途手動で削除する必要があります。
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleDeletePasskey(pk.id)}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            削除する
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                   </TableCell>
                 </TableRow>
               ))}

--- a/components/features/budget/budget-settings.tsx
+++ b/components/features/budget/budget-settings.tsx
@@ -4,6 +4,17 @@ import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { deleteBudget } from "@/app/actions/budget/delete";
 import { upsertBudget } from "@/app/actions/budget/upsert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -128,15 +139,37 @@ export function BudgetSettings({ budgets, categories }: BudgetSettingsProps) {
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="text-destructive"
-                    onClick={() => handleDelete(overallBudget.id)}
-                    disabled={isSubmitting}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="text-destructive"
+                        disabled={isSubmitting}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          予算を削除しますか？
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          全体の月間予算を削除します。この操作は取り消せません。
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => handleDelete(overallBudget.id)}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                          削除する
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </>
               )}
             </div>
@@ -198,15 +231,38 @@ export function BudgetSettings({ budgets, categories }: BudgetSettingsProps) {
                   >
                     <Pencil className="h-3 w-3" />
                   </Button>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-7 w-7 text-destructive"
-                    onClick={() => handleDelete(b.id)}
-                    disabled={isSubmitting}
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7 text-destructive"
+                        disabled={isSubmitting}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          予算を削除しますか？
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          「{b.category?.name ?? "不明"}
+                          」の予算を削除します。この操作は取り消せません。
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => handleDelete(b.id)}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                          削除する
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
Add AlertDialog confirmation to budget and passkey deletion.

### Changes
- **budget-settings.tsx**: Wrap overall and category budget delete buttons with AlertDialog
- **passkey-settings.tsx**: Replace `window.confirm()` with AlertDialog for passkey deletion

### Already implemented
- Transaction delete (AlertDialog)
- Subscription delete (AlertDialog)
- Account delete (AlertDialog)

Closes #72