### PR TITLE
Add empty state illustrations for dashboard and transaction list

### DIFF
--- a/components/features/dashboard/dashboard-view.tsx
+++ b/components/features/dashboard/dashboard-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TrendingDown, TrendingUp } from "lucide-react";
+import { BarChart3, TrendingDown, TrendingUp } from "lucide-react";
 import { CategoryPie } from "@/components/features/dashboard/charts/category-pie";
 import { MonthlyChart } from "@/components/features/dashboard/charts/monthly-chart";
 import { MonthSelector } from "@/components/features/dashboard/month-selector";
@@ -8,6 +8,7 @@ import { BudgetProgress } from "@/components/features/dashboard/widgets/budget-p
 import { RecentTransactions } from "@/components/features/dashboard/widgets/recent-transactions";
 import { StoreRanking } from "@/components/features/dashboard/widgets/store-ranking";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import type {
   SelectBudget,
   SelectCategory,
@@ -109,84 +110,95 @@ export function DashboardView({
         <MonthSelector currentMonth={currentMonth} />
       </div>
 
-      {/* サマリーカード (MoM比較付き) */}
-      <div className="grid grid-cols-3 gap-4">
-        <Card className="animate-fade-in-up stagger-1">
-          <CardContent className="pt-4 pb-3 text-center">
-            <p className="text-sm text-muted-foreground">収入</p>
-            <p className="text-xl font-bold text-blue-600">
-              +¥{summary.totalIncome.toLocaleString()}
-            </p>
-            <MoMBadge
-              current={summary.totalIncome}
-              previous={previousSummary.totalIncome}
-            />
-          </CardContent>
-        </Card>
-        <Card className="animate-fade-in-up stagger-2">
-          <CardContent className="pt-4 pb-3 text-center">
-            <p className="text-sm text-muted-foreground">支出</p>
-            <p className="text-xl font-bold text-red-600">
-              -¥{summary.totalExpense.toLocaleString()}
-            </p>
-            <MoMBadge
-              current={summary.totalExpense}
-              previous={previousSummary.totalExpense}
-            />
-          </CardContent>
-        </Card>
-        <Card className="animate-fade-in-up stagger-3">
-          <CardContent className="pt-4 pb-3 text-center">
-            <p className="text-sm text-muted-foreground">収支</p>
-            <p
-              className={`text-xl font-bold ${summary.balance >= 0 ? "text-emerald-600" : "text-red-600"}`}
-            >
-              ¥{summary.balance.toLocaleString()}
-            </p>
-            <MoMBadge
-              current={summary.balance}
-              previous={previousSummary.balance}
-            />
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* チャートエリア */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <Card className="animate-fade-in-up stagger-4">
-          <CardHeader>
-            <CardTitle>月次収支推移</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <MonthlyChart data={barData} />
-          </CardContent>
-        </Card>
-
-        <Card className="animate-fade-in-up stagger-5">
-          <CardHeader>
-            <CardTitle>今月の支出内訳</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CategoryPie data={pieData} />
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* 予算進捗 */}
-      <BudgetProgress
-        budgets={budgets}
-        totalExpense={summary.totalExpense}
-        categoryExpenses={categoryExpenses}
-      />
-
-      {/* ウィジェットエリア */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <StoreRanking data={storeRanking} />
-        <RecentTransactions
-          transactions={recentTransactions}
-          currentMonth={currentMonth}
+      {summary.totalIncome === 0 && summary.totalExpense === 0 ? (
+        <EmptyState
+          icon={BarChart3}
+          title="まずは最初の取引を記録しましょう"
+          description="収入や支出を記録すると、ここにグラフやサマリーが表示されます。"
+          action={{ label: "＋ 取引を記録する", href: "/transaction" }}
         />
-      </div>
+      ) : (
+        <>
+          {/* サマリーカード (MoM比較付き) */}
+          <div className="grid grid-cols-3 gap-4">
+            <Card className="animate-fade-in-up stagger-1">
+              <CardContent className="pt-4 pb-3 text-center">
+                <p className="text-sm text-muted-foreground">収入</p>
+                <p className="text-xl font-bold text-blue-600">
+                  +¥{summary.totalIncome.toLocaleString()}
+                </p>
+                <MoMBadge
+                  current={summary.totalIncome}
+                  previous={previousSummary.totalIncome}
+                />
+              </CardContent>
+            </Card>
+            <Card className="animate-fade-in-up stagger-2">
+              <CardContent className="pt-4 pb-3 text-center">
+                <p className="text-sm text-muted-foreground">支出</p>
+                <p className="text-xl font-bold text-red-600">
+                  -¥{summary.totalExpense.toLocaleString()}
+                </p>
+                <MoMBadge
+                  current={summary.totalExpense}
+                  previous={previousSummary.totalExpense}
+                />
+              </CardContent>
+            </Card>
+            <Card className="animate-fade-in-up stagger-3">
+              <CardContent className="pt-4 pb-3 text-center">
+                <p className="text-sm text-muted-foreground">収支</p>
+                <p
+                  className={`text-xl font-bold ${summary.balance >= 0 ? "text-emerald-600" : "text-red-600"}`}
+                >
+                  ¥{summary.balance.toLocaleString()}
+                </p>
+                <MoMBadge
+                  current={summary.balance}
+                  previous={previousSummary.balance}
+                />
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* チャートエリア */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Card className="animate-fade-in-up stagger-4">
+              <CardHeader>
+                <CardTitle>月次収支推移</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <MonthlyChart data={barData} />
+              </CardContent>
+            </Card>
+
+            <Card className="animate-fade-in-up stagger-5">
+              <CardHeader>
+                <CardTitle>今月の支出内訳</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CategoryPie data={pieData} />
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* 予算進捗 */}
+          <BudgetProgress
+            budgets={budgets}
+            totalExpense={summary.totalExpense}
+            categoryExpenses={categoryExpenses}
+          />
+
+          {/* ウィジェットエリア */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <StoreRanking data={storeRanking} />
+            <RecentTransactions
+              transactions={recentTransactions}
+              currentMonth={currentMonth}
+            />
+          </div>
+        </>
+      )}
     </main>
   );
 }

--- a/components/features/dashboard/widgets/budget-progress.tsx
+++ b/components/features/dashboard/widgets/budget-progress.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { SelectBudget, SelectCategory } from "@/db/schema";
 
@@ -67,10 +69,13 @@ export function BudgetProgress({
         <CardHeader>
           <CardTitle className="text-base">📊 予算進捗</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            予算が設定されていません。設定ページから予算を追加してください。
+        <CardContent className="flex flex-col items-center gap-3 py-6">
+          <p className="text-sm text-muted-foreground text-center">
+            まだ予算が設定されていません
           </p>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/settings">設定から予算を追加</Link>
+          </Button>
         </CardContent>
       </Card>
     );

--- a/components/features/dashboard/widgets/store-ranking.tsx
+++ b/components/features/dashboard/widgets/store-ranking.tsx
@@ -20,7 +20,7 @@ export function StoreRanking({ data }: StoreRankingProps) {
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            今月の支出データがありません
+            データが増えるとランキングが表示されます
           </p>
         </CardContent>
       </Card>

--- a/components/features/transaction/transaction-list.tsx
+++ b/components/features/transaction/transaction-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { Loader2, Receipt } from "lucide-react";
 import { useCallback, useEffect, useState, useTransition } from "react";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { PaginationControl } from "@/components/features/transaction/pagination-control";
@@ -156,11 +156,15 @@ export function TransactionList({
           ))}
           {transactions.length === 0 && (
             <TableRow>
-              <TableCell
-                colSpan={6}
-                className="text-center text-muted-foreground h-24"
-              >
-                データがありません
+              <TableCell colSpan={6} className="text-center h-40">
+                <div className="flex flex-col items-center gap-2 py-4">
+                  <div className="p-3 bg-muted/50 rounded-full">
+                    <Receipt className="h-6 w-6 text-muted-foreground/60" />
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    まだ取引がありません。左のフォームから記録しましょう
+                  </p>
+                </div>
               </TableCell>
             </TableRow>
           )}

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  action?: {
+    label: string;
+    href: string;
+  };
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center space-y-4 animate-fade-in">
+      <div className="p-4 bg-muted/50 rounded-full">
+        <Icon className="h-10 w-10 text-muted-foreground/60" />
+      </div>
+      <div className="space-y-1.5">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground max-w-sm">{description}</p>
+      </div>
+      {action && (
+        <Button asChild className="mt-2">
+          <Link href={action.href}>{action.label}</Link>
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Friendly empty states for first-time users with no data.

### Changes
- **empty-state.tsx** [NEW]: Reusable component with icon, title, description, optional CTA
- **dashboard-view.tsx**: Full empty state when totalIncome === 0 && totalExpense === 0
- **transaction-list.tsx**: Receipt icon + encouraging message
- **budget-progress.tsx**: Settings link button when no budgets set
- **store-ranking.tsx**: Friendly message for empty ranking data

Closes #67