### PR TITLE
Add optimistic UI updates for transaction deletion

### DIFF
--- a/components/features/transaction/transaction-item-menu.tsx
+++ b/components/features/transaction/transaction-item-menu.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { SelectCategory, SelectStore } from "@/db/schema";
 import { TransactionForm } from "./transaction-form";
+import type { OptimisticDeleteFn } from "./transaction-list";
 
 interface TransactionItemMenuProps {
   transaction: {
@@ -45,30 +46,32 @@ interface TransactionItemMenuProps {
   };
   categories: SelectCategory[];
   stores: SelectStore[];
+  onOptimisticDelete?: OptimisticDeleteFn;
 }
 
 export function TransactionItemMenu({
   transaction,
   categories,
   stores,
+  onOptimisticDelete,
 }: TransactionItemMenuProps) {
   const [isPending, startTransition] = useTransition();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
 
   const handleDelete = () => {
-    // confirm は削除
+    setShowDeleteDialog(false);
 
-    const toastId = toast.loading("削除しています...");
+    const rollback = onOptimisticDelete?.(transaction.id);
 
     startTransition(async () => {
       const result = await deleteTransaction(transaction.id);
 
       if (result.success) {
-        toast.success("削除しました", { id: toastId });
-        setShowDeleteDialog(false);
+        toast.success("削除しました");
       } else {
-        toast.error("削除に失敗しました", { id: toastId });
+        rollback?.restore();
+        toast.error("削除に失敗しました");
       }
     });
   };

--- a/components/features/transaction/transaction-item.tsx
+++ b/components/features/transaction/transaction-item.tsx
@@ -6,17 +6,20 @@ import type {
   SelectTransaction,
 } from "@/db/schema";
 import { TransactionItemMenu } from "./transaction-item-menu";
+import type { OptimisticDeleteFn } from "./transaction-list";
 
-interface TransactionItemProps {
+export interface TransactionItemProps {
   data: SelectTransaction;
   categories: SelectCategory[];
   stores: SelectStore[];
+  onOptimisticDelete?: OptimisticDeleteFn;
 }
 
 export function TransactionItem({
   data,
   categories,
   stores,
+  onOptimisticDelete,
 }: TransactionItemProps) {
   return (
     <TableRow key={data.id}>
@@ -45,6 +48,7 @@ export function TransactionItem({
           transaction={data}
           categories={categories}
           stores={stores}
+          onOptimisticDelete={onOptimisticDelete}
         />
       </TableCell>
     </TableRow>

--- a/components/features/transaction/transaction-list.tsx
+++ b/components/features/transaction/transaction-list.tsx
@@ -35,6 +35,8 @@ interface TransactionListProps {
   showFilters?: boolean;
 }
 
+export type OptimisticDeleteFn = (id: string) => { restore: () => void };
+
 export function TransactionList({
   initialData,
   initialMetadata,
@@ -55,6 +57,17 @@ export function TransactionList({
     setTransactions(initialData);
     setMetadata(initialMetadata);
   }, [initialMetadata, initialData]);
+
+  const optimisticDelete: OptimisticDeleteFn = useCallback(
+    (id: string) => {
+      const prev = transactions;
+      setTransactions((t) => t.filter((item) => item.id !== id));
+      return {
+        restore: () => setTransactions(prev),
+      };
+    },
+    [transactions],
+  );
 
   // データを取得する共通関数
   const fetchData = useCallback(
@@ -152,6 +165,7 @@ export function TransactionList({
               key={t.id}
               categories={categories}
               stores={stores}
+              onOptimisticDelete={optimisticDelete}
             />
           ))}
           {transactions.length === 0 && (


### PR DESCRIPTION
## Summary
Instant UI feedback for transaction deletion with error rollback.

### Changes
- **transaction-list.tsx**: `OptimisticDeleteFn` type + `optimisticDelete` callback
- **transaction-item.tsx**: Forward `onOptimisticDelete` prop
- **transaction-item-menu.tsx**: Instantly remove item from list, restore on failure

### How it works
1. User confirms delete → item vanishes immediately
2. Server action runs in background
3. On success: toast confirmation
4. On failure: item restored + error toast

Closes #71