### PR TITLE
Add delayed confirm to all destructive action dialogs

### DIFF
--- a/components/features/settings/delete-account-button.tsx
+++ b/components/features/settings/delete-account-button.tsx
@@ -17,10 +17,13 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { useDelayedConfirm } from "@/hooks/use-delayed-confirm";
 import { signOut } from "@/lib/auth/client";
 
 export function DeleteAccountButton() {
   const [isDeleting, setIsDeleting] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const confirmLocked = useDelayedConfirm(dialogOpen);
 
   const router = useRouter();
 
@@ -39,7 +42,7 @@ export function DeleteAccountButton() {
   };
 
   return (
-    <AlertDialog>
+    <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <AlertDialogTrigger asChild>
         <Button variant="destructive" disabled={isDeleting}>
           {isDeleting ? (
@@ -66,6 +69,7 @@ export function DeleteAccountButton() {
               handleDelete();
             }}
             className="bg-destructive text-white hover:bg-destructive/90"
+            disabled={confirmLocked}
           >
             {isDeleting ? "削除中..." : "削除する"}
           </AlertDialogAction>

--- a/components/features/transaction/transaction-item-menu.tsx
+++ b/components/features/transaction/transaction-item-menu.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { SelectCategory, SelectStore } from "@/db/schema";
+import { useDelayedConfirm } from "@/hooks/use-delayed-confirm";
 import { TransactionForm } from "./transaction-form";
 import type { OptimisticDeleteFn } from "./transaction-list";
 
@@ -58,6 +59,7 @@ export function TransactionItemMenu({
   const [isPending, startTransition] = useTransition();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
+  const confirmLocked = useDelayedConfirm(showDeleteDialog);
 
   const handleDelete = () => {
     setShowDeleteDialog(false);
@@ -118,7 +120,7 @@ export function TransactionItemMenu({
                 handleDelete();
               }}
               className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
-              disabled={isPending}
+              disabled={isPending || confirmLocked}
             >
               {isPending ? "削除中..." : "削除する"}
             </AlertDialogAction>

--- a/hooks/use-delayed-confirm.ts
+++ b/hooks/use-delayed-confirm.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Delays enabling a confirm button to prevent accidental double-clicks.
+ * Returns `true` while the timer is running (button should be disabled).
+ */
+export function useDelayedConfirm(open: boolean, delayMs = 500) {
+  const [locked, setLocked] = useState(true);
+
+  useEffect(() => {
+    if (!open) {
+      setLocked(true);
+      return;
+    }
+    const id = setTimeout(() => setLocked(false), delayMs);
+    return () => clearTimeout(id);
+  }, [open, delayMs]);
+
+  return locked;
+}


### PR DESCRIPTION
## Summary
Adds 500ms delay before destructive confirm buttons become clickable to prevent accidental double-clicks.

### Changes
- **use-delayed-confirm.ts** [NEW]: Hook that returns `locked=true` for 500ms after dialog opens
- **transaction-item-menu.tsx**: Apply delayed confirm to transaction delete
- **delete-account-button.tsx**: Apply delayed confirm to account delete

All existing dialogs already had consistent design (title, warning, cancel/confirm with destructive variant). This PR adds the safety delay.

Closes #72