### PR TITLE
chore: add agent rules and skills configuration

### DIFF
--- a/.agents/rules/branching-policy.md
+++ b/.agents/rules/branching-policy.md
@@ -1,0 +1,40 @@
+# Branching Policy
+
+## Protected Branches
+
+`develop` and `main` are **merge-only** branches. Direct commits are **strictly prohibited**.
+
+## Mandatory Branch Workflow
+
+ALL changes — regardless of size or type — MUST follow this flow:
+
+1. Create a dedicated branch from `develop` (`feature/`, `fix/`, `refactor/`, `docs/`, `chore/`)
+2. Commit changes on that branch
+3. Push and create a PR targeting `develop`
+4. Merge via PR (with `--delete-branch`)
+
+**No exceptions**: formatting fixes, biome auto-fixes, config changes, package installs, single-line edits — everything requires a branch.
+
+## Pre-Commit Guard
+
+Before EVERY `git add` or `git commit`, run:
+
+```bash
+git branch --show-current
+```
+
+If the output is `develop` or `main`, **STOP immediately** and create a branch first.
+
+## Commit Conventions
+
+- `feat:` new features
+- `fix:` bug fixes
+- `refactor:` code restructuring
+- `chore:` tooling, config, dependencies
+- `docs:` documentation
+- `style:` formatting (no logic change)
+
+## Flags
+
+- **NEVER** use `--no-verify` — husky hooks must always run
+- **NEVER** force-push to `develop` or `main`

--- a/.agents/rules/coding-conventions.md
+++ b/.agents/rules/coding-conventions.md
@@ -1,0 +1,54 @@
+# Coding Conventions
+
+## TypeScript
+
+- **Strict mode enabled** (`strict: true` in tsconfig)
+- Always use explicit types for function parameters and return values
+- Prefer `type` over `interface` for object shapes (project convention)
+- Use `@/` path alias for all imports (configured in tsconfig)
+- Never use `any` — use `unknown` and narrow with type guards
+- Use `import type { ... }` for type-only imports
+
+## Next.js (App Router)
+
+### Server vs Client Components
+
+- **Default to Server Components** — only add `"use client"` when needed
+- Use `"use client"` only for: event handlers, hooks (useState, useEffect, etc.), browser APIs
+- Server Actions go in `app/actions/<domain>/<action>.ts`
+- Data fetching belongs in Server Components, not Client Components
+
+### File Conventions
+
+| File | Purpose |
+|------|---------|
+| `page.tsx` | Route page (Server Component) |
+| `loading.tsx` | Suspense loading UI |
+| `error.tsx` | Error boundary (`"use client"`) |
+| `layout.tsx` | Shared layout |
+
+### Route Groups
+
+- `(main)` for authenticated routes
+- `(auth)` for login/signup routes
+
+## Biome
+
+- Biome is the **sole** linter/formatter (no ESLint/Prettier)
+- Config: `biome.json` at project root
+- Auto-fix: `npx biome check --write .`
+- Verify: `npx biome check . --diagnostic-level=error`
+- Import organization is handled by Biome — do not manually sort
+
+## Code Style
+
+- Prefer named exports over default exports (except for pages)
+- One component per file
+- File naming: kebab-case (`my-component.tsx`), PascalCase for components (`MyComponent`)
+- No AI-style verbose comments — only comment non-obvious logic
+
+## Language
+
+- Issues, PRs, commits, CHANGELOG: **English**
+- UI text: **Japanese**
+- Code comments: **English** (brief, human-style)

--- a/.agents/rules/testing-policy.md
+++ b/.agents/rules/testing-policy.md
@@ -1,0 +1,45 @@
+# Testing Policy
+
+## Test Stack
+
+| Tool | Purpose | Location |
+|------|---------|----------|
+| Vitest | Unit tests for server actions and utilities | `**/*.test.ts` |
+| Storybook | Component visual testing and documentation | `**/*.stories.tsx` |
+| Playwright | E2E integration tests | `e2e/**/*.spec.ts` |
+
+## Test Requirements
+
+### Server Actions (`app/actions/`)
+
+- Every server action MUST have a corresponding `.test.ts` file
+- Mock `db` from `@/db` — never hit a real database
+- Test: success, validation failure, and error cases
+
+### UI Components (`components/features/`)
+
+- Every new/modified component MUST have a Storybook story
+- Stories go alongside the component file
+- Cover: default, loading, empty, error states
+
+### E2E Tests (`e2e/`)
+
+- Cover critical user flows
+- Playwright Chromium only (`--project=chromium --workers=1`)
+
+## Automatic Checks (Husky)
+
+- **pre-commit**: `lint-staged` (Biome on staged files)
+- **pre-push**: `vitest --changed` (related tests only)
+
+## Manual Checks (Before PR)
+
+```bash
+npx vitest run
+npx playwright test --project=chromium --workers=1
+```
+
+## Quality Gate
+
+- ALL tests must pass before creating a PR
+- Zero test failures required for merge

--- a/.agents/rules/ui-design.md
+++ b/.agents/rules/ui-design.md
@@ -1,0 +1,39 @@
+# UI Design Rules
+
+## Component Library
+
+- **Always use shadcn/ui components first** — check `components/ui/` before creating custom ones
+- Custom feature components: `components/features/<domain>/`
+- Reusable layout components: `components/layouts/`
+
+## Styling
+
+- Use **Tailwind CSS utility classes** for all styling
+- Use `cn()` from `lib/utils.ts` (clsx + tailwind-merge) for conditional classes:
+
+```tsx
+import { cn } from "@/lib/utils";
+<div className={cn("base-class", condition && "conditional-class")} />
+```
+
+- Never use inline `style={}` attributes
+- Never create CSS modules — use `globals.css` for global styles only
+- CSS variables defined in `globals.css` under `:root` and `.dark`
+
+## Accessibility
+
+- Interactive elements must have accessible labels
+- Use semantic HTML (`<main>`, `<nav>`, `<section>`)
+- Support keyboard navigation (visible focus rings)
+- Respect `prefers-reduced-motion` for animations
+
+## Icons
+
+- Use **lucide-react** icons
+- Standard: `h-4 w-4` inline, `h-5 w-5` headers
+
+## Destructive Actions
+
+- ALL delete/remove actions MUST use `AlertDialog` from shadcn/ui
+- Apply `useDelayedConfirm` hook (500ms safety delay)
+- Destructive buttons use `variant="destructive"`

--- a/.agents/skills/database-management/SKILL.md
+++ b/.agents/skills/database-management/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: database-management
+description: Drizzle ORM schema changes, migration generation, and Neon database branch operations. Use when modifying database tables, columns, indexes, or managing database branches.
+---
+
+# Database Management Skill
+
+## Schema Definition
+
+- Schema file: `db/schema.ts`
+- ORM: Drizzle ORM with PostgreSQL dialect
+- Database: Neon Serverless Postgres
+- Connection: `db/index.ts` using `@neondatabase/serverless`
+
+## Schema Change Workflow
+
+1. **Edit schema** in `db/schema.ts`
+2. **Generate migration**:
+   ```bash
+   npx drizzle-kit generate
+   ```
+3. **Review** the generated SQL in `drizzle/` directory
+4. **Apply migration**:
+   ```bash
+   npx drizzle-kit migrate
+   ```
+5. **Verify** with Drizzle Studio:
+   ```bash
+   npx drizzle-kit studio
+   ```
+
+## Neon MCP Operations
+
+Use the `neon-mcp` MCP server for database operations:
+
+- `mcp_neon-mcp_list_projects` — Find project ID
+- `mcp_neon-mcp_create_branch` — Create a test branch before risky migrations
+- `mcp_neon-mcp_run_sql` — Execute SQL directly
+- `mcp_neon-mcp_describe_table_schema` — Inspect table structure
+- `mcp_neon-mcp_compare_database_schema` — Diff branches before merging
+
+## Safety Rules
+
+- Always create a Neon branch before destructive schema changes (DROP TABLE, DROP COLUMN)
+- Test migrations on a branch before applying to main
+- Never run raw SQL DELETE/DROP on the main branch without confirmation
+- Config: `drizzle.config.ts` reads `POSTGRES_URL` from `.env.local`

--- a/.agents/skills/deployment-workflow/SKILL.md
+++ b/.agents/skills/deployment-workflow/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: deployment-workflow
+description: Vercel deployment monitoring, GitHub PR/Issue automation, and CI/CD troubleshooting. Use when deploying, checking build logs, managing PRs, or resolving deployment errors.
+---
+
+# Deployment Workflow Skill
+
+## Vercel Deployment
+
+### MCP Tools
+
+- `mcp_vercel-mcp_deploy_to_vercel` — Trigger deployment
+- `mcp_vercel-mcp_list_deployments` — List recent deployments
+- `mcp_vercel-mcp_get_deployment` — Get deployment details
+- `mcp_vercel-mcp_get_deployment_build_logs` — Read build logs for debugging
+- `mcp_vercel-mcp_get_runtime_logs` — Check runtime errors in production
+- `mcp_vercel-mcp_search_vercel_documentation` — Search Vercel docs
+
+### Debugging Failed Deployments
+
+1. Get deployment ID: `mcp_vercel-mcp_list_deployments`
+2. Read build logs: `mcp_vercel-mcp_get_deployment_build_logs`
+3. Identify error and fix in codebase
+4. Push fix and redeploy
+
+### Environment
+
+- Team/Org ID: Check `.vercel/project.json` or use `mcp_vercel-mcp_list_teams`
+- Project ID: Check `.vercel/project.json` or use `mcp_vercel-mcp_list_projects`
+
+## GitHub Automation
+
+### MCP Tools
+
+- `mcp_github-mcp-server_create_issue` — Create issues
+- `mcp_github-mcp-server_create_pull_request` — Create PRs
+- `mcp_github-mcp-server_merge_pull_request` — Merge PRs
+- `mcp_github-mcp-server_get_pull_request_files` — Review PR changes
+- `mcp_github-mcp-server_list_issues` — List open issues
+
+### PR Workflow
+
+1. Feature PRs target `develop` with `Relates to #<issue>`
+2. Release PRs target `main` with `Closes #<issue>` for each resolved issue
+3. Always use `--merge --delete-branch` when merging
+
+### Issue Management
+
+- Every task starts with a GitHub Issue
+- Use `gh issue close` only after merge to `main` (via release PR)
+- Owner/Repo: `shun2218-dev/asset-lens`


### PR DESCRIPTION
## Summary

Add always-on rules and auto-activated skills to `.agents/` directory based on [official Antigravity documentation](https://antigravity.google/docs/rules-workflows).

### Rules (Always-On Constraints)
- **branching-policy.md** — Branch protection: never commit directly to `develop` or `main`
- **coding-conventions.md** — TypeScript/Next.js/Biome standards
- **ui-design.md** — shadcn/ui + Tailwind CSS conventions
- **testing-policy.md** — Vitest/Storybook/Playwright requirements

### Skills (Auto-Activated Procedures)
- **database-management** — Drizzle ORM schema changes + Neon MCP operations
- **deployment-workflow** — Vercel deployment monitoring + GitHub PR/Issue automation

### Why
Rules are loaded every conversation (unlike workflows which require `/command`), solving the recurring issue of direct commits to `develop`.

### What Changed
- New: `.agents/rules/` (4 files)
- New: `.agents/skills/` (2 SKILL.md files)
- No code changes