### PR TITLE
feat: add dark mode support with next-themes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "sonner";
 import { SiteFooter } from "@/components/layouts/site-footer";
 import { SiteHeader } from "@/components/layouts/site-header";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,17 +27,24 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <a href="#main-content" className="skip-to-content">
-          メインコンテンツへスキップ
-        </a>
-        <SiteHeader />
-        <main id="main-content">{children}</main>
-        <Toaster />
-        <SiteFooter />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <a href="#main-content" className="skip-to-content">
+            メインコンテンツへスキップ
+          </a>
+          <SiteHeader />
+          <main id="main-content">{children}</main>
+          <Toaster />
+          <SiteFooter />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -4,6 +4,7 @@ import { LogIn, LogOut, Settings, User, Wallet } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { QuickEntryDialog } from "@/components/features/transaction/quick-entry-dialog";
+import { ThemeToggle } from "@/components/layouts/theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -78,6 +79,7 @@ export function SiteHeader() {
         {/* 右側: クイック入力 + ユーザーメニュー */}
         <div className="flex items-center gap-2">
           {!isPending && session && <QuickEntryDialog />}
+          <ThemeToggle />
           {isPending ? (
             <Skeleton className="h-8 w-8 rounded-full" />
           ) : session ? (

--- a/components/layouts/theme-toggle.tsx
+++ b/components/layouts/theme-toggle.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle() {
+  const { setTheme, theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="h-8 w-8" disabled>
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">テーマ切り替え</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-8 w-8">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">テーマ切り替え</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => setTheme("light")}
+          className={theme === "light" ? "bg-accent" : ""}
+        >
+          <Sun className="mr-2 h-4 w-4" />
+          ライト
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme("dark")}
+          className={theme === "dark" ? "bg-accent" : ""}
+        >
+          <Moon className="mr-2 h-4 w-4" />
+          ダーク
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setTheme("system")}
+          className={theme === "system" ? "bg-accent" : ""}
+        >
+          <Monitor className="mr-2 h-4 w-4" />
+          システム
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asset-lens",
-  "version": "2.12.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asset-lens",
-      "version": "2.12.1",
+      "version": "2.14.0",
       "dependencies": {
         "@better-auth/passkey": "^1.4.10",
         "@google/generative-ai": "^0.24.1",
@@ -31,6 +31,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "next-themes": "^0.4.6",
         "papaparse": "^5.5.3",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
@@ -10226,6 +10227,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "next-themes": "^0.4.6",
     "papaparse": "^5.5.3",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",


### PR DESCRIPTION
## Summary

Add dark mode support using `next-themes`. Users can toggle between light, dark, and system themes.

### Changes
- **New**: `components/providers/theme-provider.tsx` — next-themes wrapper
- **New**: `components/layouts/theme-toggle.tsx` — Dropdown with sun/moon icons
- **Modified**: `app/layout.tsx` — ThemeProvider integration with `attribute="class"`
- **Modified**: `components/layouts/site-header.tsx` — ThemeToggle in header

### Implementation
- Dark CSS variables were already defined in `globals.css` (`.dark` selector)
- `next-themes` reads/writes user preference to localStorage
- `defaultTheme="system"` respects OS preference
- `suppressHydrationWarning` on `<html>` prevents SSR mismatch
- Theme toggle shows current selection with accent highlight

### Testing
- All 190 tests pass (71 test files)
- Biome check passes

Relates to #29