### PR TITLE
perf: add unstable_cache for categories, stores, and budgets

### DIFF
--- a/app/actions/budget/delete.test.ts
+++ b/app/actions/budget/delete.test.ts
@@ -4,6 +4,7 @@ import { deleteBudget } from "./delete";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({

--- a/app/actions/budget/delete.ts
+++ b/app/actions/budget/delete.ts
@@ -1,11 +1,12 @@
 "use server";
 
 import { and, eq } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { budget } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { budgetTag } from "@/lib/cache/tags";
 import type { ActionResult } from "@/types";
 
 export async function deleteBudget(id: string): Promise<ActionResult> {
@@ -22,6 +23,7 @@ export async function deleteBudget(id: string): Promise<ActionResult> {
       .delete(budget)
       .where(and(eq(budget.id, id), eq(budget.userId, session.user.id)));
 
+    updateTag(budgetTag(session.user.id));
     revalidatePath("/dashboard");
     revalidatePath("/settings");
     return { success: true };

--- a/app/actions/budget/get.ts
+++ b/app/actions/budget/get.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { eq } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { budget } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { budgetTag } from "@/lib/cache/tags";
 
 export async function getBudgets() {
   const session = await auth.api.getSession({
@@ -15,13 +17,27 @@ export async function getBudgets() {
     return [];
   }
 
-  try {
-    return await db.query.budget.findMany({
-      where: eq(budget.userId, session.user.id),
-      with: { category: true },
-    });
-  } catch (error) {
-    console.error("Failed to get budgets:", error);
-    return [];
-  }
+  return getBudgetsCached(session.user.id)();
+}
+
+/** Cached budget query — revalidated via budgetTag */
+function getBudgetsCached(userId: string) {
+  return unstable_cache(
+    async () => {
+      try {
+        return await db.query.budget.findMany({
+          where: eq(budget.userId, userId),
+          with: { category: true },
+        });
+      } catch (error) {
+        console.error("Failed to get budgets:", error);
+        return [];
+      }
+    },
+    [`budgets-${userId}`],
+    {
+      tags: [budgetTag(userId)],
+      revalidate: 3600,
+    },
+  );
 }

--- a/app/actions/budget/upsert.test.ts
+++ b/app/actions/budget/upsert.test.ts
@@ -4,6 +4,7 @@ import { upsertBudget } from "./upsert";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({

--- a/app/actions/budget/upsert.ts
+++ b/app/actions/budget/upsert.ts
@@ -1,11 +1,12 @@
 "use server";
 
 import { and, eq, isNull } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { budget } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { budgetTag } from "@/lib/cache/tags";
 import type { ActionResult } from "@/types";
 
 interface UpsertBudgetData {
@@ -54,6 +55,7 @@ export async function upsertBudget(
       });
     }
 
+    updateTag(budgetTag(session.user.id));
     revalidatePath("/dashboard");
     revalidatePath("/settings");
     return { success: true };

--- a/app/actions/category/create.test.ts
+++ b/app/actions/category/create.test.ts
@@ -5,6 +5,7 @@ import { createCustomCategory } from "./create";
 // Mock next/cache
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
 }));
 
 // Mock next/headers

--- a/app/actions/category/create.ts
+++ b/app/actions/category/create.ts
@@ -1,11 +1,12 @@
 // app/actions/category/create.ts
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { category } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { categoryTag } from "@/lib/cache/tags";
 
 export async function createCustomCategory(name: string) {
   const session = await auth.api.getSession({
@@ -29,6 +30,7 @@ export async function createCustomCategory(name: string) {
       sortOrder: 100,
     });
 
+    updateTag(categoryTag(session.user.id));
     revalidatePath("/dashboard");
     revalidatePath("/settings");
 

--- a/app/actions/category/get.test.ts
+++ b/app/actions/category/get.test.ts
@@ -7,6 +7,11 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
+// Mock next/cache
+vi.mock("next/cache", () => ({
+  unstable_cache: vi.fn((fn: Function) => fn),
+}));
+
 // Mock auth
 vi.mock("@/lib/auth", () => ({
   auth: {

--- a/app/actions/category/get.ts
+++ b/app/actions/category/get.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { asc, eq, isNull, or } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { category } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { categoryTag } from "@/lib/cache/tags";
 
 export async function getCategories() {
   const session = await auth.api.getSession({
@@ -13,16 +15,30 @@ export async function getCategories() {
 
   if (!session) return [];
 
-  try {
-    const categories = await db
-      .select()
-      .from(category)
-      .where(or(isNull(category.userId), eq(category.userId, session.user.id)))
-      .orderBy(asc(category.sortOrder), asc(category.createdAt));
+  return getCategoriesCached(session.user.id)();
+}
 
-    return categories;
-  } catch (error) {
-    console.error("Failed to fetch categories:", error);
-    return [];
-  }
+/** Cached category query — revalidated via categoryTag */
+function getCategoriesCached(userId: string) {
+  return unstable_cache(
+    async () => {
+      try {
+        const categories = await db
+          .select()
+          .from(category)
+          .where(or(isNull(category.userId), eq(category.userId, userId)))
+          .orderBy(asc(category.sortOrder), asc(category.createdAt));
+
+        return categories;
+      } catch (error) {
+        console.error("Failed to fetch categories:", error);
+        return [];
+      }
+    },
+    [`categories-${userId}`],
+    {
+      tags: [categoryTag(userId)],
+      revalidate: 3600, // 1 hour fallback
+    },
+  );
 }

--- a/app/actions/store/get.test.ts
+++ b/app/actions/store/get.test.ts
@@ -7,6 +7,11 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
+// Mock next/cache
+vi.mock("next/cache", () => ({
+  unstable_cache: vi.fn((fn: Function) => fn),
+}));
+
 // Mock auth
 vi.mock("@/lib/auth", () => ({
   auth: {

--- a/app/actions/store/get.ts
+++ b/app/actions/store/get.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { eq } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { store } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { storeTag } from "@/lib/cache/tags";
 
 export async function getStores() {
   const session = await auth.api.getSession({
@@ -15,16 +17,30 @@ export async function getStores() {
     return [];
   }
 
-  try {
-    const stores = await db
-      .select()
-      .from(store)
-      .where(eq(store.userId, session.user.id))
-      .orderBy(store.name);
+  return getStoresCached(session.user.id)();
+}
 
-    return stores;
-  } catch (error) {
-    console.error("Failed to fetch stores:", error);
-    return [];
-  }
+/** Cached store query — revalidated via storeTag */
+function getStoresCached(userId: string) {
+  return unstable_cache(
+    async () => {
+      try {
+        const stores = await db
+          .select()
+          .from(store)
+          .where(eq(store.userId, userId))
+          .orderBy(store.name);
+
+        return stores;
+      } catch (error) {
+        console.error("Failed to fetch stores:", error);
+        return [];
+      }
+    },
+    [`stores-${userId}`],
+    {
+      tags: [storeTag(userId)],
+      revalidate: 3600,
+    },
+  );
 }

--- a/lib/cache/tags.ts
+++ b/lib/cache/tags.ts
@@ -1,0 +1,21 @@
+/**
+ * Centralized cache tag definitions for revalidation.
+ * Use these constants with `unstable_cache` tags and `revalidateTag`.
+ */
+
+/** Per-user cache tag for categories */
+export const categoryTag = (userId: string) => `categories-${userId}`;
+
+/** Per-user cache tag for stores */
+export const storeTag = (userId: string) => `stores-${userId}`;
+
+/** Per-user cache tag for budgets */
+export const budgetTag = (userId: string) => `budgets-${userId}`;
+
+/** Per-user cache tag for transactions (month-scoped) */
+export const transactionTag = (userId: string, month?: string) =>
+  month ? `transactions-${userId}-${month}` : `transactions-${userId}`;
+
+/** Per-user cache tag for summaries (month-scoped) */
+export const summaryTag = (userId: string, month: string) =>
+  `summary-${userId}-${month}`;


### PR DESCRIPTION
## Summary

Add cross-request caching for frequently accessed, low-mutation data to reduce TTFB.

### Changes
- **New**: `lib/cache/tags.ts` — Centralized cache tag definitions
- **Modified**: `app/actions/category/get.ts` — Wrap with `unstable_cache` (1h revalidate)
- **Modified**: `app/actions/store/get.ts` — Wrap with `unstable_cache` (1h revalidate) 
- **Modified**: `app/actions/budget/get.ts` — Wrap with `unstable_cache` (1h revalidate)
- **Modified**: `app/actions/category/create.ts` — Add `updateTag` for cache invalidation
- **Modified**: `app/actions/budget/upsert.ts` — Add `updateTag` for cache invalidation
- **Modified**: `app/actions/budget/delete.ts` — Add `updateTag` for cache invalidation
- **Modified**: 5 test files — Add `unstable_cache` and `updateTag` mocks

### Implementation
- Dashboard already uses `Promise.all()` — no waterfall to fix
- Categories, stores, budgets change infrequently → ideal for `unstable_cache`
- Mutations use Next.js 16's `updateTag()` API for on-demand invalidation
- Tags are user-scoped: `categories-{userId}`, `stores-{userId}`, `budgets-{userId}`

### Testing
- All 190 tests pass (71 test files)
- Biome: 0 errors

Relates to #70