### PR TITLE
perf: lazy-load chart components and bulk form with next/dynamic

### DIFF
--- a/components/features/dashboard/dashboard-view.tsx
+++ b/components/features/dashboard/dashboard-view.tsx
@@ -1,20 +1,37 @@
 "use client";
 
 import { BarChart3, TrendingDown, TrendingUp } from "lucide-react";
-import { CategoryPie } from "@/components/features/dashboard/charts/category-pie";
-import { MonthlyChart } from "@/components/features/dashboard/charts/monthly-chart";
+import dynamic from "next/dynamic";
 import { MonthSelector } from "@/components/features/dashboard/month-selector";
 import { BudgetProgress } from "@/components/features/dashboard/widgets/budget-progress";
 import { RecentTransactions } from "@/components/features/dashboard/widgets/recent-transactions";
 import { StoreRanking } from "@/components/features/dashboard/widgets/store-ranking";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import type {
   SelectBudget,
   SelectCategory,
   SelectTransaction,
 } from "@/db/schema";
 import type { CategoryStats, MonthlyStats, SummaryStats } from "@/types";
+
+/** Lazy-loaded chart components (recharts is ~200KB) */
+const MonthlyChart = dynamic(
+  () =>
+    import("@/components/features/dashboard/charts/monthly-chart").then(
+      (mod) => mod.MonthlyChart,
+    ),
+  { loading: () => <Skeleton className="h-[300px] w-full rounded-lg" /> },
+);
+
+const CategoryPie = dynamic(
+  () =>
+    import("@/components/features/dashboard/charts/category-pie").then(
+      (mod) => mod.CategoryPie,
+    ),
+  { loading: () => <Skeleton className="h-[300px] w-full rounded-lg" /> },
+);
 
 interface StoreRankingItem {
   storeName: string;

--- a/components/features/transaction/transaction-page-view.tsx
+++ b/components/features/transaction/transaction-page-view.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { BulkTransactionForm } from "@/components/features/transaction/bulk-transaction-form";
+import dynamic from "next/dynamic";
 import { TransactionForm } from "@/components/features/transaction/transaction-form";
 import { TransactionList } from "@/components/features/transaction/transaction-list";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+/** Lazy-loaded — only rendered when bulk tab is selected */
+const BulkTransactionForm = dynamic(
+  () =>
+    import("@/components/features/transaction/bulk-transaction-form").then(
+      (mod) => mod.BulkTransactionForm,
+    ),
+  { loading: () => <Skeleton className="h-[400px] w-full rounded-lg" /> },
+);
+
 import type {
   SelectCategory,
   SelectStore,

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import { LogIn, LogOut, Settings, User, Wallet } from "lucide-react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { QuickEntryDialog } from "@/components/features/transaction/quick-entry-dialog";
+
+const QuickEntryDialog = dynamic(
+  () =>
+    import("@/components/features/transaction/quick-entry-dialog").then(
+      (mod) => mod.QuickEntryDialog,
+    ),
+  { ssr: false },
+);
+
 import { ThemeToggle } from "@/components/layouts/theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary

Reduce initial JS bundle size by lazy-loading heavy components that aren't immediately visible.

### Changes
- **`dashboard-view.tsx`**: Lazy-load `MonthlyChart` and `CategoryPie` (recharts ~200KB) with Skeleton fallback
- **`transaction-page-view.tsx`**: Lazy-load `BulkTransactionForm` (only visible when bulk tab selected)
- **`site-header.tsx`**: Lazy-load `QuickEntryDialog` (`ssr: false`, dialog trigger only)

### Impact
- Dashboard initial JS bundle reduced by deferring recharts
- Transaction page initial JS reduced by deferring bulk form
- Skeleton loading states provide smooth UX during lazy load
- All 190 tests pass, 0 lint errors

Relates to #74