### PR TITLE
feat: add keyboard shortcuts for power users

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import { KeyboardShortcutProvider } from "@/components/features/shortcuts/keyboard-shortcut-provider";
 import { SiteFooter } from "@/components/layouts/site-footer";
 import { SiteHeader } from "@/components/layouts/site-header";
 import { ThemeProvider } from "@/components/providers/theme-provider";
@@ -40,10 +41,12 @@ export default function RootLayout({
           <a href="#main-content" className="skip-to-content">
             メインコンテンツへスキップ
           </a>
-          <SiteHeader />
-          <main id="main-content">{children}</main>
-          <Toaster />
-          <SiteFooter />
+          <KeyboardShortcutProvider>
+            <SiteHeader />
+            <main id="main-content">{children}</main>
+            <Toaster />
+            <SiteFooter />
+          </KeyboardShortcutProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/features/shortcuts/keyboard-shortcut-provider.tsx
+++ b/components/features/shortcuts/keyboard-shortcut-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useNavigationShortcuts } from "@/hooks/use-keyboard-shortcuts";
+
+const ShortcutHelpDialog = dynamic(
+  () =>
+    import("@/components/features/shortcuts/shortcut-help-dialog").then(
+      (mod) => mod.ShortcutHelpDialog,
+    ),
+  { ssr: false },
+);
+
+interface KeyboardShortcutProviderProps {
+  children: React.ReactNode;
+}
+
+export function KeyboardShortcutProvider({
+  children,
+}: KeyboardShortcutProviderProps) {
+  useNavigationShortcuts();
+
+  return (
+    <>
+      {children}
+      <ShortcutHelpDialog />
+    </>
+  );
+}

--- a/components/features/shortcuts/shortcut-help-dialog.stories.tsx
+++ b/components/features/shortcuts/shortcut-help-dialog.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ShortcutHelpDialog } from "./shortcut-help-dialog";
+
+const meta: Meta<typeof ShortcutHelpDialog> = {
+  title: "Features/Shortcuts/ShortcutHelpDialog",
+  component: ShortcutHelpDialog,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShortcutHelpDialog>;
+
+export const Default: Story = {
+  render: () => <ShortcutHelpDialog />,
+};

--- a/components/features/shortcuts/shortcut-help-dialog.tsx
+++ b/components/features/shortcuts/shortcut-help-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: { keys: string[]; description: string }[];
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: "一般",
+    shortcuts: [
+      { keys: ["⌘", "K"], description: "取引をすばやく記録" },
+      { keys: ["?"], description: "ショートカット一覧を表示" },
+    ],
+  },
+  {
+    title: "ナビゲーション",
+    shortcuts: [
+      { keys: ["G", "D"], description: "ダッシュボードへ移動" },
+      { keys: ["G", "T"], description: "取引一覧へ移動" },
+      { keys: ["G", "S"], description: "設定へ移動" },
+    ],
+  },
+];
+
+export function ShortcutHelpDialog() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable;
+
+      if (isInput) return;
+
+      if (e.key === "?" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        className="sm:max-w-[480px]"
+        id="shortcut-help-dialog"
+        aria-describedby="shortcut-help-description"
+      >
+        <DialogHeader>
+          <DialogTitle>キーボードショートカット</DialogTitle>
+        </DialogHeader>
+        <p id="shortcut-help-description" className="sr-only">
+          利用可能なキーボードショートカットの一覧です
+        </p>
+        <div className="space-y-6">
+          {SHORTCUT_GROUPS.map((group) => (
+            <div key={group.title}>
+              <h3 className="text-sm font-medium text-muted-foreground mb-3">
+                {group.title}
+              </h3>
+              <div className="space-y-2">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={shortcut.description}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="text-sm">{shortcut.description}</span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key, i) => (
+                        <span key={`${shortcut.description}-${key}-${i}`}>
+                          {i > 0 && (
+                            <span className="text-muted-foreground mx-0.5 text-xs">
+                              then
+                            </span>
+                          )}
+                          <kbd className="inline-flex items-center justify-center min-w-[28px] h-7 px-1.5 bg-muted border border-border rounded-md text-xs font-mono font-medium shadow-sm">
+                            {key}
+                          </kbd>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/features/transaction/quick-entry-dialog.tsx
+++ b/components/features/transaction/quick-entry-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Plus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getCategories } from "@/app/actions/category/get";
 import { getStores } from "@/app/actions/store/get";
 import { TransactionForm } from "@/components/features/transaction/transaction-form";
@@ -30,6 +30,17 @@ export function QuickEntryDialog() {
       });
     }
   }, [open, loaded]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react";
+
+interface ShortcutHandler {
+  key: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+  handler: () => void;
+  description: string;
+}
+
+export function useKeyboardShortcuts(
+  shortcuts: ShortcutHandler[],
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable;
+
+      if (isInput) return;
+
+      for (const shortcut of shortcuts) {
+        const metaMatch = shortcut.meta ? e.metaKey || e.ctrlKey : true;
+        const ctrlMatch = shortcut.ctrl ? e.ctrlKey : true;
+        const shiftMatch = shortcut.shift ? e.shiftKey : true;
+        const keyMatch = e.key.toLowerCase() === shortcut.key.toLowerCase();
+
+        if (keyMatch && metaMatch && ctrlMatch && shiftMatch) {
+          if (shortcut.meta || shortcut.ctrl) {
+            e.preventDefault();
+          }
+          shortcut.handler();
+          return;
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [shortcuts, enabled]);
+}
+
+/**
+ * Sequence-based shortcuts (e.g., G then D for dashboard).
+ * First key press starts the sequence, second key completes it.
+ */
+export function useSequenceShortcuts(
+  sequences: Record<string, () => void>,
+  prefix: string,
+  enabled = true,
+) {
+  const pendingRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable;
+
+      if (isInput) return;
+
+      const key = e.key.toLowerCase();
+
+      if (pendingRef.current) {
+        pendingRef.current = false;
+        if (timerRef.current) clearTimeout(timerRef.current);
+
+        const handler = sequences[key];
+        if (handler) {
+          e.preventDefault();
+          handler();
+        }
+        return;
+      }
+
+      if (key === prefix.toLowerCase()) {
+        pendingRef.current = true;
+        timerRef.current = setTimeout(() => {
+          pendingRef.current = false;
+        }, 1000);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [sequences, prefix, enabled]);
+}
+
+/**
+ * Pre-built navigation shortcuts: G then D/T/S
+ */
+export function useNavigationShortcuts(enabled = true) {
+  const router = useRouter();
+
+  const sequences = useCallback(
+    () => ({
+      d: () => router.push("/dashboard"),
+      t: () => router.push("/transaction"),
+      s: () => router.push("/settings"),
+    }),
+    [router],
+  );
+
+  useSequenceShortcuts(sequences(), "g", enabled);
+}


### PR DESCRIPTION
## Summary

Add keyboard shortcuts for power users to improve efficiency.

### Features
- **Cmd+K** (or Ctrl+K): Open/close quick entry dialog
- **G → D**: Navigate to dashboard
- **G → T**: Navigate to transactions
- **G → S**: Navigate to settings
- **?**: Open shortcut help modal

### Implementation
- `hooks/use-keyboard-shortcuts.ts`: Reusable hooks for single-key, modifier+key, and sequence-based shortcuts
- `components/features/shortcuts/keyboard-shortcut-provider.tsx`: Global provider wrapping root layout
- `components/features/shortcuts/shortcut-help-dialog.tsx`: Help modal with categorized shortcut list
- Storybook story for ShortcutHelpDialog

### Test Results
- 191/191 tests passing

Relates to #45