### PR TITLE
feat: add category management UI with CRUD operations

### DIFF
--- a/app/actions/category/create.ts
+++ b/app/actions/category/create.ts
@@ -8,7 +8,14 @@ import { category } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { categoryTag } from "@/lib/cache/tags";
 
-export async function createCustomCategory(name: string) {
+interface CreateCategoryInput {
+  name: string;
+  type?: "expense" | "income";
+}
+
+export async function createCustomCategory(
+  input: string | CreateCategoryInput,
+) {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -17,15 +24,20 @@ export async function createCustomCategory(name: string) {
     throw new Error("Unauthorized");
   }
 
+  // Support both string (backward compat) and object input
+  const name = typeof input === "string" ? input : input.name;
+  const type =
+    typeof input === "string" ? "expense" : (input.type ?? "expense");
+
   if (!name.trim()) {
     throw new Error("カテゴリ名を入力してください");
   }
 
   try {
     await db.insert(category).values({
-      name: name,
+      name: name.trim(),
       slug: `custom_${crypto.randomUUID().split("-")[0]}`,
-      type: "expense",
+      type,
       userId: session.user.id,
       sortOrder: 100,
     });

--- a/app/actions/category/delete.test.ts
+++ b/app/actions/category/delete.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db";
+import { deleteCategory } from "./delete";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("@/db", () => {
+  return {
+    db: {
+      select: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/mail/client", () => ({
+  resend: {
+    emails: {
+      send: vi.fn(),
+    },
+  },
+}));
+
+describe("deleteCategory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should successfully delete a category with no transactions", async () => {
+    // Mock select chain - no linked transactions
+    const limitMock = vi.fn().mockResolvedValue([]);
+    const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    (db.select as any).mockReturnValue({ from: fromMock });
+
+    // Mock delete chain
+    const deleteWhereMock = vi.fn().mockResolvedValue([]);
+    (db.delete as any).mockReturnValue({ where: deleteWhereMock });
+
+    const result = await deleteCategory("cat-123");
+
+    expect(result.success).toBe(true);
+    expect(db.delete).toHaveBeenCalled();
+  });
+
+  it("should prevent deletion if transactions exist", async () => {
+    // Mock select chain - has linked transactions
+    const limitMock = vi.fn().mockResolvedValue([{ id: "tx-1" }]);
+    const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    (db.select as any).mockReturnValue({ from: fromMock });
+
+    const result = await deleteCategory("cat-123");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("紐づく取引がある");
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it("should throw error if unauthorized", async () => {
+    const { auth } = await import("@/lib/auth");
+    (auth.api.getSession as any).mockResolvedValueOnce(null);
+
+    await expect(deleteCategory("cat-123")).rejects.toThrow("Unauthorized");
+  });
+
+  it("should return error on database failure", async () => {
+    // Mock select failure
+    const fromMock = vi.fn().mockImplementation(() => {
+      throw new Error("DB Error");
+    });
+    (db.select as any).mockReturnValue({ from: fromMock });
+
+    const result = await deleteCategory("cat-123");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("カテゴリの削除に失敗しました");
+  });
+});

--- a/app/actions/category/delete.ts
+++ b/app/actions/category/delete.ts
@@ -1,0 +1,52 @@
+// app/actions/category/delete.ts
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath, updateTag } from "next/cache";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { category, transaction } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { categoryTag } from "@/lib/cache/tags";
+
+export async function deleteCategory(categoryId: string) {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  try {
+    // Check if category has linked transactions
+    const linkedTransactions = await db
+      .select({ id: transaction.id })
+      .from(transaction)
+      .where(eq(transaction.categoryId, categoryId))
+      .limit(1);
+
+    if (linkedTransactions.length > 0) {
+      return {
+        success: false,
+        error:
+          "このカテゴリに紐づく取引があるため削除できません。先に取引のカテゴリを変更してください。",
+      };
+    }
+
+    await db
+      .delete(category)
+      .where(
+        and(eq(category.id, categoryId), eq(category.userId, session.user.id)),
+      );
+
+    updateTag(categoryTag(session.user.id));
+    revalidatePath("/settings");
+    revalidatePath("/dashboard");
+
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to delete category:", error);
+    return { success: false, error: "カテゴリの削除に失敗しました" };
+  }
+}

--- a/app/actions/category/update.test.ts
+++ b/app/actions/category/update.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/db";
+import { updateCategory } from "./update";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("@/db", () => {
+  return {
+    db: {
+      update: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/mail/client", () => ({
+  resend: {
+    emails: {
+      send: vi.fn(),
+    },
+  },
+}));
+
+describe("updateCategory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should successfully update a category", async () => {
+    const whereMock = vi.fn().mockResolvedValue([{ id: "cat-123" }]);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    (db.update as any).mockReturnValue({ set: setMock });
+
+    const result = await updateCategory({
+      id: "cat-123",
+      name: "Updated Name",
+      type: "income",
+    });
+
+    expect(result.success).toBe(true);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("should throw error if unauthorized", async () => {
+    const { auth } = await import("@/lib/auth");
+    (auth.api.getSession as any).mockResolvedValueOnce(null);
+
+    await expect(
+      updateCategory({ id: "cat-123", name: "Test", type: "expense" }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("should return error if name is empty", async () => {
+    const result = await updateCategory({
+      id: "cat-123",
+      name: "  ",
+      type: "expense",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("カテゴリ名を入力してください");
+  });
+
+  it("should return error on database failure", async () => {
+    const setMock = vi.fn().mockImplementation(() => {
+      throw new Error("DB Error");
+    });
+    (db.update as any).mockReturnValue({ set: setMock });
+
+    const result = await updateCategory({
+      id: "cat-123",
+      name: "Test",
+      type: "expense",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("カテゴリの更新に失敗しました");
+  });
+});

--- a/app/actions/category/update.ts
+++ b/app/actions/category/update.ts
@@ -1,0 +1,54 @@
+// app/actions/category/update.ts
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath, updateTag } from "next/cache";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { category } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { categoryTag } from "@/lib/cache/tags";
+
+interface UpdateCategoryInput {
+  id: string;
+  name: string;
+  type: "expense" | "income";
+  sortOrder?: number;
+}
+
+export async function updateCategory(input: UpdateCategoryInput) {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  if (!input.name.trim()) {
+    return { success: false, error: "カテゴリ名を入力してください" };
+  }
+
+  try {
+    const result = await db
+      .update(category)
+      .set({
+        name: input.name.trim(),
+        type: input.type,
+        sortOrder: input.sortOrder,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(category.id, input.id), eq(category.userId, session.user.id)),
+      );
+
+    updateTag(categoryTag(session.user.id));
+    revalidatePath("/settings");
+    revalidatePath("/dashboard");
+
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to update category:", error);
+    return { success: false, error: "カテゴリの更新に失敗しました" };
+  }
+}

--- a/components/features/category/category-manager.tsx
+++ b/components/features/category/category-manager.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { Pencil, Plus, Tag, Trash2 } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { createCustomCategory } from "@/app/actions/category/create";
+import { deleteCategory } from "@/app/actions/category/delete";
+import { updateCategory } from "@/app/actions/category/update";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SelectCategory } from "@/db/schema";
+
+interface CategoryManagerProps {
+  categories: SelectCategory[];
+}
+
+export function CategoryManager({ categories }: CategoryManagerProps) {
+  const [isPending, startTransition] = useTransition();
+  const [editingCategory, setEditingCategory] = useState<SelectCategory | null>(
+    null,
+  );
+  const [deletingCategory, setDeletingCategory] =
+    useState<SelectCategory | null>(null);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  // Form state
+  const [formName, setFormName] = useState("");
+  const [formType, setFormType] = useState<"expense" | "income">("expense");
+
+  const systemCategories = categories.filter((c) => !c.userId);
+  const userCategories = categories.filter((c) => c.userId);
+
+  function openEditDialog(cat: SelectCategory) {
+    setFormName(cat.name);
+    setFormType(cat.type as "expense" | "income");
+    setEditingCategory(cat);
+  }
+
+  function openCreateDialog() {
+    setFormName("");
+    setFormType("expense");
+    setShowCreateDialog(true);
+  }
+
+  function handleCreate() {
+    startTransition(async () => {
+      const result = await createCustomCategory({
+        name: formName,
+        type: formType,
+      });
+      if (result.success) {
+        toast.success("カテゴリを作成しました");
+        setShowCreateDialog(false);
+      } else {
+        toast.error(result.error ?? "作成に失敗しました");
+      }
+    });
+  }
+
+  function handleUpdate() {
+    if (!editingCategory) return;
+    startTransition(async () => {
+      const result = await updateCategory({
+        id: editingCategory.id,
+        name: formName,
+        type: formType,
+      });
+      if (result.success) {
+        toast.success("カテゴリを更新しました");
+        setEditingCategory(null);
+      } else {
+        toast.error(result.error ?? "更新に失敗しました");
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!deletingCategory) return;
+    startTransition(async () => {
+      const result = await deleteCategory(deletingCategory.id);
+      if (result.success) {
+        toast.success("カテゴリを削除しました");
+        setDeletingCategory(null);
+      } else {
+        toast.error(result.error ?? "削除に失敗しました");
+      }
+    });
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Tag className="h-5 w-5" />
+                カテゴリ管理
+              </CardTitle>
+              <CardDescription>
+                カスタムカテゴリの作成・編集・削除ができます
+              </CardDescription>
+            </div>
+            <Button
+              size="sm"
+              onClick={openCreateDialog}
+              className="gap-1.5"
+              id="create-category-button"
+            >
+              <Plus className="h-4 w-4" />
+              新規作成
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* User categories */}
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-3">
+              カスタムカテゴリ
+            </h4>
+            {userCategories.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                カスタムカテゴリはまだありません
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {userCategories.map((cat) => (
+                  <div
+                    key={cat.id}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm font-medium">{cat.name}</span>
+                      <Badge
+                        variant={
+                          cat.type === "income" ? "default" : "secondary"
+                        }
+                      >
+                        {cat.type === "income" ? "収入" : "支出"}
+                      </Badge>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEditDialog(cat)}
+                        aria-label={`${cat.name}を編集`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setDeletingCategory(cat)}
+                        className="text-destructive hover:text-destructive"
+                        aria-label={`${cat.name}を削除`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* System categories */}
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-3">
+              システムカテゴリ
+            </h4>
+            <div className="space-y-2">
+              {systemCategories.map((cat) => (
+                <div
+                  key={cat.id}
+                  className="flex items-center justify-between rounded-lg border border-dashed p-3 opacity-70"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium">{cat.name}</span>
+                    <Badge variant="outline">
+                      {cat.type === "income" ? "収入" : "支出"}
+                    </Badge>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    編集不可
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>カテゴリを作成</DialogTitle>
+            <DialogDescription>
+              新しいカスタムカテゴリを作成します
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="category-name">カテゴリ名</Label>
+              <Input
+                id="category-name"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例: 交際費"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="category-type">タイプ</Label>
+              <Select
+                value={formType}
+                onValueChange={(v) => setFormType(v as "expense" | "income")}
+              >
+                <SelectTrigger id="category-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="expense">支出</SelectItem>
+                  <SelectItem value="income">収入</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowCreateDialog(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={isPending || !formName.trim()}
+            >
+              {isPending ? "作成中..." : "作成"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={!!editingCategory}
+        onOpenChange={(open) => !open && setEditingCategory(null)}
+      >
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>カテゴリを編集</DialogTitle>
+            <DialogDescription>
+              カテゴリの名前やタイプを変更します
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="edit-category-name">カテゴリ名</Label>
+              <Input
+                id="edit-category-name"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例: 交際費"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-category-type">タイプ</Label>
+              <Select
+                value={formType}
+                onValueChange={(v) => setFormType(v as "expense" | "income")}
+              >
+                <SelectTrigger id="edit-category-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="expense">支出</SelectItem>
+                  <SelectItem value="income">収入</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingCategory(null)}>
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleUpdate}
+              disabled={isPending || !formName.trim()}
+            >
+              {isPending ? "保存中..." : "保存"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={!!deletingCategory}
+        onOpenChange={(open) => !open && setDeletingCategory(null)}
+      >
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>カテゴリを削除</DialogTitle>
+            <DialogDescription>
+              「{deletingCategory?.name}」を削除しますか？
+              この操作は取り消せません。紐づく取引がある場合は削除できません。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeletingCategory(null)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isPending}
+            >
+              {isPending ? "削除中..." : "削除"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/features/settings/settings-view.tsx
+++ b/components/features/settings/settings-view.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import type { Session } from "better-auth";
-import { AlertTriangle, FileText, Shield, Store } from "lucide-react";
+import { AlertTriangle, FileText, Shield, Store, Tag } from "lucide-react";
 import { PasskeySettings } from "@/components/features/auth/passkey-settings";
 import { PasswordSettings } from "@/components/features/auth/password-settings";
 import { BudgetSettings } from "@/components/features/budget/budget-settings";
+import { CategoryManager } from "@/components/features/category/category-manager";
 import { DeleteAccountButton } from "@/components/features/settings/delete-account-button";
 import { ExportButton } from "@/components/features/settings/export-button";
 import { ImportButton } from "@/components/features/settings/import-button";
@@ -60,8 +61,9 @@ export function SettingsView({
       <Separator />
 
       <Tabs defaultValue="account" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:w-150">
+        <TabsList className="grid w-full grid-cols-5 lg:w-175">
           <TabsTrigger value="account">アカウント</TabsTrigger>
+          <TabsTrigger value="category">カテゴリ</TabsTrigger>
           <TabsTrigger value="budget">予算</TabsTrigger>
           <TabsTrigger value="data">データ管理</TabsTrigger>
           <TabsTrigger value="subscription">サブスク</TabsTrigger>
@@ -105,6 +107,11 @@ export function SettingsView({
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        {/* --- タブ: カテゴリ管理 --- */}
+        <TabsContent value="category" className="space-y-6">
+          <CategoryManager categories={categories} />
         </TabsContent>
 
         {/* --- タブ: 予算管理 --- */}


### PR DESCRIPTION
## Summary

Add category management UI to the settings page, allowing users to create, edit, and delete custom categories.

### Features
- **Category tab** in settings with system vs user category distinction
- **Create dialog**: Name + type (expense/income) input
- **Edit dialog**: Update name and type of custom categories
- **Delete dialog**: Confirmation with protection against deleting categories that have linked transactions
- System categories are displayed as read-only with dashed borders

### Server Actions
- `updateCategory`: Update name, type, sortOrder with ownership validation
- `deleteCategory`: Delete with transaction-existence check
- `createCustomCategory`: Enhanced to accept `{name, type}` object (backward compatible with string input)

### Tests
- 199/199 tests passing (+8 new tests for update/delete actions)

Relates to #43