### PR TITLE
feat: add SEO metadata, OGP tags, manifest, and robots.txt

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,4 +1,12 @@
 import { format, subMonths } from "date-fns";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ダッシュボード",
+  description:
+    "月次収支推移、カテゴリ別支出、予算進捗を一目で確認。家計の全体像を把握できるダッシュボード。",
+};
+
 import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
 import { getSummary } from "@/app/actions/analysis/get-summary";
 import { getBudgets } from "@/app/actions/budget/get";

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from "next";
 import { getBudgets } from "@/app/actions/budget/get";
+
+export const metadata: Metadata = {
+  title: "設定",
+  description:
+    "アカウント管理、カテゴリ設定、予算管理、データ入出力、サブスクリプション管理。",
+};
+
 import { getCategories } from "@/app/actions/category/get";
 import { getSubscription } from "@/app/actions/subscription/get";
 import { SettingsView } from "@/components/features/settings/settings-view";

--- a/app/(main)/transaction/page.tsx
+++ b/app/(main)/transaction/page.tsx
@@ -1,4 +1,12 @@
 import { format } from "date-fns";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "取引一覧",
+  description:
+    "収入・支出の履歴を検索・フィルタ・ソート。取引データの一元管理と新規記録。",
+};
+
 import { getCategories } from "@/app/actions/category/get";
 import { getStores } from "@/app/actions/store/get";
 import { getTransaction } from "@/app/actions/transaction/get";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,43 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "AssetLens",
-  description: "Personal Finance App",
+  title: {
+    default: "AssetLens - スマート家計管理",
+    template: "%s | AssetLens",
+  },
+  description:
+    "収支を記録・分析して家計を最適化。予算管理、カテゴリ別支出分析、サブスクリプション管理など、暮らしのお金を見える化するパーソナルファイナンスアプリ。",
+  keywords: [
+    "家計簿",
+    "家計管理",
+    "収支管理",
+    "予算管理",
+    "支出分析",
+    "asset management",
+  ],
+  authors: [{ name: "AssetLens" }],
+  creator: "AssetLens",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "https://asset-lens.vercel.app",
+  ),
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    siteName: "AssetLens",
+    title: "AssetLens - スマート家計管理",
+    description:
+      "収支を記録・分析して家計を最適化するパーソナルファイナンスアプリ。",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AssetLens - スマート家計管理",
+    description:
+      "収支を記録・分析して家計を最適化するパーソナルファイナンスアプリ。",
+  },
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/favicon.ico",
+  },
 };
 
 export default function RootLayout({

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "AssetLens",
+  "short_name": "AssetLens",
+  "description": "収支を記録・分析して家計を最適化するパーソナルファイナンスアプリ",
+  "start_url": "/dashboard",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1a1a2e",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /dashboard
+Disallow: /transaction
+Disallow: /settings
+Disallow: /profile
+
+Sitemap: https://asset-lens.vercel.app/sitemap.xml


### PR DESCRIPTION
## Summary

Add comprehensive SEO metadata, Open Graph Protocol tags, PWA manifest, and robots.txt for improved search engine visibility and social media link previews.

## Changes

### Root Layout (`app/layout.tsx`)
- Title template: `%s | AssetLens` with default "AssetLens - スマート家計管理"
- Rich description with keywords for Japanese search optimization
- Open Graph tags (type, locale, siteName, title, description)
- Twitter card configuration (summary_large_image)
- Manifest and favicon references
- `metadataBase` configuration for canonical URLs

### Page-Specific Metadata
- **Dashboard**: "ダッシュボード | AssetLens" with analytics-focused description
- **Transaction**: "取引一覧 | AssetLens" with search/filter-focused description
- **Settings**: "設定 | AssetLens" with management-focused description

### Public Assets
- `manifest.json`: PWA identity, theme color, standalone display mode
- `robots.txt`: Allows public pages, blocks authenticated routes (/dashboard, /transaction, /settings, /api)

## Testing

- [x] 202 unit tests pass ✅
- [x] Biome lint clean

Relates to #112