### PR TITLE
docs: add English-only language policy for GitHub artifacts

### DIFF
--- a/.agents/rules/branching-policy.md
+++ b/.agents/rules/branching-policy.md
@@ -52,6 +52,19 @@ If changes span multiple concerns (e.g., feature code + workflow rule update + l
 - `docs:` documentation
 - `style:` formatting (no logic change)
 
+## GitHub Language Policy
+
+ALL GitHub artifacts MUST be written in **English only**:
+
+- **Issue titles and body**
+- **PR titles and body**
+- **Commit messages**
+- **Branch names**
+- **CHANGELOG entries**
+- **Code comments** (inline and JSDoc)
+
+No exceptions — Japanese is NOT permitted in any of the above.
+
 ## Flags
 
 - **NEVER** use `--no-verify` — husky hooks must always run


### PR DESCRIPTION
## Changes
- Add GitHub Language Policy section to `.agents/rules/branching-policy.md`
- All Issue titles/body, PR titles/body, commit messages, branch names, CHANGELOG entries, and code comments must be in English
- No exceptions

## Related cleanup
- Updated 4 existing Issues (#105, #108, #109, #111) from Japanese to English (titles and body)