### PR TITLE
test: integrate Vitest coverage reporting with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npx vitest run
+      - name: Generate coverage report
+        run: npm run test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
 
   e2e-tests:
     name: E2E Tests

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-storybook": "storybook build",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:coverage": "vitest run --project unit --coverage",
     "prepare": "husky"
   },
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,23 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["app/actions/**", "lib/**", "hooks/**"],
+      exclude: [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.stories.tsx",
+        "**/*.d.ts",
+      ],
+      thresholds: {
+        statements: 45,
+        branches: 35,
+        functions: 40,
+        lines: 45,
+      },
+    },
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Summary

Configure test coverage measurement and CI integration using @vitest/coverage-v8.

## Changes

### vitest.config.ts
- Add `coverage` configuration with v8 provider
- Reporters: text (terminal), html (browsable), lcov (CI tools)
- Scope: `app/actions/**`, `lib/**`, `hooks/**`
- Baseline thresholds set to current levels (stmts: 45%, branches: 35%, functions: 40%, lines: 45%)

### package.json
- Add `test:coverage` npm script

### .github/workflows/ci.yml
- Add coverage generation step after unit tests
- Upload coverage as downloadable artifact

Relates to #107