### PR TITLE
test: integrate Chromatic visual regression testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,27 @@ jobs:
           name: coverage-report
           path: coverage/
 
+  chromatic:
+    name: Visual Regression (Chromatic)
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitZeroOnChanges: true
+          autoAcceptChanges: "main"
+          onlyChanged: true
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asset-lens",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asset-lens",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "dependencies": {
         "@better-auth/passkey": "^1.4.10",
         "@google/generative-ai": "^0.24.1",
@@ -64,6 +64,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/browser-playwright": "^4.0.16",
         "@vitest/coverage-v8": "^4.0.16",
+        "chromatic": "^16.0.0",
         "dotenv": "^17.2.3",
         "drizzle-kit": "^0.31.8",
         "husky": "^9.1.7",
@@ -761,6 +762,30 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
+      "version": "13.3.5",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
+      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@chromatic-com/cypress": {
+          "optional": true
+        },
+        "@chromatic-com/playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -8020,9 +8045,9 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
-      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.0.0.tgz",
+      "integrity": "sha512-O81RVGDXXoreNeG894hjaUx08xep+C/BA6aJNMZkwSjH7Lln8IweZekBpBEoQPNNpjmHyZvcTIwN/aGitdK53Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:coverage": "vitest run --project unit --coverage",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "prepare": "husky"
   },
   "dependencies": {
@@ -76,6 +77,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/browser-playwright": "^4.0.16",
     "@vitest/coverage-v8": "^4.0.16",
+    "chromatic": "^16.0.0",
     "dotenv": "^17.2.3",
     "drizzle-kit": "^0.31.8",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary

Integrate Chromatic for automated visual regression testing on every PR.

## Changes

### package.json
- Install `chromatic` CLI
- Add `chromatic` npm script

### .github/workflows/ci.yml
- New `chromatic` job using `chromaui/action`
- `onlyChanged: true` — TurboSnap for faster builds (only snapshots changed stories)
- `autoAcceptChanges: main` — auto-accept on main merges (new baseline)
- `exitZeroOnChanges: true` — don't fail CI, just report changes
- `fetch-depth: 0` — full git history for accurate change detection
- Runs in parallel with unit-tests (only depends on lint)

## How It Works
1. On every PR, Chromatic builds Storybook and takes screenshots of all 40 stories
2. Compares against the baseline (auto-accepted on main)
3. Visual changes are reported in the PR — review on chromatic.com
4. First run on this PR will establish the initial baseline

Relates to #122