### PR TITLE
fix(a11y): add DialogDescription to all Dialog components

### DIFF
--- a/components/features/shortcuts/shortcut-help-dialog.tsx
+++ b/components/features/shortcuts/shortcut-help-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -57,17 +58,13 @@ export function ShortcutHelpDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent
-        className="sm:max-w-[480px]"
-        id="shortcut-help-dialog"
-        aria-describedby="shortcut-help-description"
-      >
+      <DialogContent className="sm:max-w-[480px]" id="shortcut-help-dialog">
         <DialogHeader>
           <DialogTitle>キーボードショートカット</DialogTitle>
+          <DialogDescription>
+            利用可能なキーボードショートカットの一覧です
+          </DialogDescription>
         </DialogHeader>
-        <p id="shortcut-help-description" className="sr-only">
-          利用可能なキーボードショートカットの一覧です
-        </p>
         <div className="space-y-6">
           {SHORTCUT_GROUPS.map((group) => (
             <div key={group.title}>

--- a/components/features/transaction/quick-entry-dialog.tsx
+++ b/components/features/transaction/quick-entry-dialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -53,6 +54,9 @@ export function QuickEntryDialog() {
       <DialogContent className="sm:max-w-[480px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>取引を記録</DialogTitle>
+          <DialogDescription>
+            収入・支出の取引情報を入力してください
+          </DialogDescription>
         </DialogHeader>
         {loaded ? (
           <TransactionForm

--- a/components/layouts/bottom-nav.tsx
+++ b/components/layouts/bottom-nav.tsx
@@ -16,6 +16,7 @@ import { TransactionForm } from "@/components/features/transaction/transaction-f
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -112,6 +113,9 @@ export function BottomNav() {
         <DialogContent className="sm:max-w-[480px] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>取引を記録</DialogTitle>
+            <DialogDescription>
+              収入・支出の取引情報を入力してください
+            </DialogDescription>
           </DialogHeader>
           {loaded ? (
             <TransactionForm


### PR DESCRIPTION
## Summary

Fix console warning: `Missing Description or aria-describedby={undefined} for {DialogContent}`

### Changes
- **quick-entry-dialog.tsx**: Add `<DialogDescription>`
- **bottom-nav.tsx**: Add `<DialogDescription>`
- **shortcut-help-dialog.tsx**: Replace manual `aria-describedby` with `<DialogDescription>` for consistency

### Already Correct (no changes needed)
- All `AlertDialogContent` usages had `AlertDialogDescription` ✅
- `category-manager.tsx` all 3 dialogs had `DialogDescription` ✅
- `transaction-item-menu.tsx` both dialogs had descriptions ✅

Relates to #173