### PR TITLE
feat: create footer link pages (Terms, Privacy, Contact)

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,91 @@
+import { Mail } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "お問い合わせ",
+  description:
+    "AssetLensに関するお問い合わせ・ご質問・ご意見はこちらからお寄せください。",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-16 md:py-24">
+      <h1 className="text-3xl font-bold tracking-tight mb-8">お問い合わせ</h1>
+
+      <div className="space-y-8">
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
+          <div className="flex items-start gap-4">
+            <div className="p-3 bg-primary/10 rounded-full shrink-0">
+              <Mail className="h-6 w-6 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold mb-2">
+                メールでのお問い合わせ
+              </h2>
+              <p className="text-muted-foreground leading-relaxed mb-4">
+                ご質問、ご意見、不具合の報告など、お気軽にお問い合わせください。
+                通常2〜3営業日以内にご返信いたします。
+              </p>
+              <a
+                href="mailto:support@asset-lens.app"
+                className="inline-flex items-center gap-2 text-primary hover:underline font-medium"
+              >
+                <Mail className="h-4 w-4" />
+                support@asset-lens.app
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
+          <h2 className="text-lg font-semibold mb-4">よくある質問</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="font-medium mb-1">アカウントを削除したいです</h3>
+              <p className="text-sm text-muted-foreground">
+                設定画面の「アカウント削除」ボタンから削除できます。削除後のデータ復元はできません。
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium mb-1">
+                データのエクスポートはできますか？
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                現在开発中の機能です。今後のアップデートでCSV/PDFエクスポートに対応予定です。
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium mb-1">パスキーを紛失しました</h3>
+              <p className="text-sm text-muted-foreground">
+                メールアドレスとパスワードでもログインできます。ログイン後、設定画面から新しいパスキーを登録してください。
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-lg border bg-card p-6 shadow-sm">
+          <h2 className="text-lg font-semibold mb-4">バグの報告</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            不具合を見つけた場合は、以下の情報を添えてご報告いただけると迅速に対応できます。
+          </p>
+          <ul className="list-disc pl-6 space-y-1 text-sm text-muted-foreground mt-3">
+            <li>発生した操作の手順</li>
+            <li>期待される動作と実際の動作</li>
+            <li>ブラウザの種類とバージョン</li>
+            <li>スクリーンショット（可能であれば）</li>
+          </ul>
+        </section>
+      </div>
+
+      <div className="mt-12 pt-8 border-t">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← トップページに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "プライバシーポリシー",
+  description:
+    "AssetLensのプライバシーポリシーです。個人情報の取り扱いについて説明しています。",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-16 md:py-24">
+      <h1 className="text-3xl font-bold tracking-tight mb-8">
+        プライバシーポリシー
+      </h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        最終更新日: 2026年3月31日
+      </p>
+
+      <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8">
+        <section>
+          <h2 className="text-xl font-semibold mb-4">1. 収集する情報</h2>
+          <p className="text-muted-foreground leading-relaxed mb-3">
+            本サービスでは、以下の情報を収集する場合があります。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>
+              <strong>アカウント情報</strong>:
+              メールアドレス、表示名、プロフィール画像
+            </li>
+            <li>
+              <strong>認証情報</strong>:
+              パスキー（WebAuthn）の公開鍵情報（秘密鍵はデバイスに保存されます）
+            </li>
+            <li>
+              <strong>利用データ</strong>:
+              取引記録、カテゴリ分類、予算設定、サブスクリプション情報
+            </li>
+            <li>
+              <strong>技術情報</strong>:
+              ブラウザ種別、IPアドレス（ログイン時のセキュリティ目的）
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">2. 情報の利用目的</h2>
+          <p className="text-muted-foreground leading-relaxed mb-3">
+            収集した情報は、以下の目的で利用します。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>本サービスの提供・運営・改善</li>
+            <li>ユーザーアカウントの管理と認証</li>
+            <li>収支データの保存と分析機能の提供</li>
+            <li>サービスに関する重要なお知らせの送信</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">3. 情報の第三者提供</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            運営者は、法令に基づく場合を除き、ユーザーの個人情報を第三者に提供しません。
+            ただし、以下の場合はこの限りではありません。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground mt-3">
+            <li>ユーザーの同意がある場合</li>
+            <li>法令に基づき開示が必要な場合</li>
+            <li>
+              サービス提供に必要な範囲でのインフラパートナーへの委託（データベースホスティング等）
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">
+            4. データの保管と安全管理
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">
+            ユーザーデータは暗号化された通信（TLS）を通じて送受信され、セキュアなクラウドインフラストラクチャに保管されます。
+            パスワードはハッシュ化して保存され、平文での保存は行いません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">5. データの削除</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            ユーザーはいつでも設定画面からアカウントを削除できます。
+            アカウント削除時には、関連するすべてのデータ（取引記録、カテゴリ、予算設定等）が完全に削除されます。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">6. Cookieの使用</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            本サービスでは、セッション管理およびテーマ設定の保持のためにCookieを使用します。
+            これらのCookieは本サービスの正常な動作に必要なものです。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">7. ポリシーの変更</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            本ポリシーは予告なく変更されることがあります。
+            重要な変更がある場合は、本ページにて通知します。
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 pt-8 border-t">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← トップページに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "利用規約",
+  description:
+    "AssetLensの利用規約です。本サービスのご利用にあたっての条件を定めています。",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-16 md:py-24">
+      <h1 className="text-3xl font-bold tracking-tight mb-8">利用規約</h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        最終更新日: 2026年3月31日
+      </p>
+
+      <div className="prose prose-neutral dark:prose-invert max-w-none space-y-8">
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第1条（適用）</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            本利用規約（以下「本規約」）は、AssetLens（以下「本サービス」）の利用に関する条件を定めるものです。
+            ユーザーは本規約に同意した上で本サービスを利用するものとします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第2条（アカウント）</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            ユーザーは、本サービスの利用にあたり、正確な情報を提供してアカウントを作成するものとします。
+            アカウント情報の管理はユーザーの責任において行うものとし、第三者への譲渡・貸与はできません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第3条（禁止事項）</h2>
+          <p className="text-muted-foreground leading-relaxed mb-3">
+            ユーザーは、以下の行為を行ってはなりません。
+          </p>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>法令または公序良俗に違反する行為</li>
+            <li>本サービスの運営を妨害する行為</li>
+            <li>他のユーザーの情報を不正に取得する行為</li>
+            <li>本サービスを不正な目的で利用する行為</li>
+            <li>その他、運営者が不適切と判断する行為</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">
+            第4条（サービスの変更・停止）
+          </h2>
+          <p className="text-muted-foreground leading-relaxed">
+            運営者は、ユーザーに事前に通知することなく、本サービスの内容を変更し、または本サービスの提供を停止・中断することができるものとします。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第5条（免責事項）</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            運営者は、本サービスに起因してユーザーに生じたあらゆる損害について、一切の責任を負いません。
+            本サービスで提供される情報は、財務アドバイスを構成するものではありません。
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">第6条（規約の変更）</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            運営者は、必要と判断した場合、ユーザーに通知することなく本規約を変更できるものとします。
+            変更後の規約は、本ページに掲載した時点から効力を生じるものとします。
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-12 pt-8 border-t">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← トップページに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Create the 3 footer link pages that currently return 404:

- `/terms` — Terms of Service (6 articles covering usage, accounts, prohibited actions, liability, changes)
- `/privacy` — Privacy Policy (data collection, usage, third-party sharing, security, deletion, cookies)
- `/contact` — Contact page (email, FAQ section, bug reporting guidelines)

All pages include proper `<Metadata>` for SEO, consistent styling, and back-to-top navigation.

Relates to #174