### PR TITLE
test(e2e): add footer pages rendering tests

### DIFF
--- a/e2e/footer-pages.spec.ts
+++ b/e2e/footer-pages.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+const FOOTER_PAGES = [
+  {
+    path: "/terms",
+    heading: "利用規約",
+    sections: ["第1条", "第2条", "第3条"],
+  },
+  {
+    path: "/privacy",
+    heading: "プライバシーポリシー",
+    sections: ["収集する情報", "情報の利用目的", "データの削除"],
+  },
+  {
+    path: "/contact",
+    heading: "お問い合わせ",
+    sections: ["メールでのお問い合わせ", "よくある質問", "バグの報告"],
+  },
+] as const;
+
+test.describe("Footer Pages: Static Content", () => {
+  for (const page of FOOTER_PAGES) {
+    test(`${page.path} renders with correct heading and content`, async ({
+      page: browserPage,
+    }) => {
+      const response = await browserPage.goto(page.path);
+
+      // Page loads successfully
+      expect(response?.status()).toBe(200);
+
+      // Main heading is visible
+      await expect(
+        browserPage.getByRole("heading", { level: 1, name: page.heading }),
+      ).toBeVisible();
+
+      // Key sections are present
+      for (const section of page.sections) {
+        await expect(browserPage.getByText(section).first()).toBeVisible();
+      }
+
+      // Back-to-top link exists
+      await expect(
+        browserPage.getByRole("link", { name: /トップページに戻る/ }),
+      ).toBeVisible();
+    });
+  }
+
+  test("footer links navigate to correct pages", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Footer may be hidden on mobile, so check desktop viewport
+    const footer = page.locator("footer");
+    if (await footer.isVisible()) {
+      for (const { path } of FOOTER_PAGES) {
+        const link = footer.locator(`a[href="${path}"]`);
+        await expect(link).toBeAttached();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add E2E tests for the footer link pages created in #180.

### Tests
- Verify 200 response status for `/terms`, `/privacy`, `/contact`
- Assert correct `<h1>` heading on each page
- Check key content sections are visible
- Verify back-to-top navigation link
- Check footer link `<a>` elements are present on landing page

No authentication required — these are public static pages.

Relates to #174