### PR TITLE
chore: add bulk date assignment to project-sync + mandatory self-review step

### DIFF
--- a/.agents/skills/project-sync/SKILL.md
+++ b/.agents/skills/project-sync/SKILL.md
@@ -120,6 +120,121 @@ for item in data.get('items', []):
 
 ---
 
+## Bulk Date Assignment (after milestone changes or new Issues)
+
+Use this when multiple Issues are missing Start/Target dates on the project board.
+
+### Strategy
+- Dates are derived from the Milestone's period
+- Items within the same Milestone are sequenced 4 days apart
+- If an item's calculated end exceeds the Milestone due date, it's capped
+
+### Milestone Periods
+
+| Milestone | Start | End |
+|-----------|-------|-----|
+| v2.21 — Mobile & Accessibility | 2026-04-01 | 2026-04-29 |
+| v2.22 — UX Enhancements | 2026-04-30 | 2026-05-14 |
+| v2.23 — Quality & Security | 2026-05-15 | 2026-05-30 |
+| v2.24 — Data & Analytics | 2026-06-01 | 2026-06-14 |
+| v2.25 — Transaction UX | 2026-06-15 | 2026-06-29 |
+| v3.0 — Platform Expansion | 2026-06-15 | 2026-06-29 |
+| v3.1 — Advanced Platform | 2026-07-01 | 2026-08-30 |
+
+### Bulk Assign Script
+```bash
+gh project item-list 1 --owner shun2218-dev --format json > /tmp/project_items.json
+python3 << 'PYEOF'
+import json, subprocess
+from datetime import datetime, timedelta
+
+with open('/tmp/project_items.json') as f:
+    data = json.load(f)
+
+milestone_dates = {
+    'v2.21': ('2026-04-01', '2026-04-29'),
+    'v2.22': ('2026-04-30', '2026-05-14'),
+    'v2.23': ('2026-05-15', '2026-05-30'),
+    'v2.24': ('2026-06-01', '2026-06-14'),
+    'v2.25': ('2026-06-15', '2026-06-29'),
+    'v3.0':  ('2026-06-15', '2026-06-29'),
+    'v3.1':  ('2026-07-01', '2026-08-30'),
+}
+
+PROJECT_ID = 'PVT_kwHOBQUjOs4BTRBF'
+START_FIELD = 'PVTF_lAHOBQUjOs4BTRBFzhAjo8M'
+TARGET_FIELD = 'PVTF_lAHOBQUjOs4BTRBFzhAjo8Q'
+
+# Get issue -> milestone mapping
+res = subprocess.run(
+    ['gh','issue','list','--state','open','--json','number,title,milestone','--limit','100'],
+    capture_output=True, text=True
+)
+issues = json.loads(res.stdout)
+issue_ms = {}
+for iss in issues:
+    ms = iss.get('milestone',{})
+    if ms:
+        mt = ms.get('title','')
+        for k in milestone_dates:
+            if k in mt:
+                issue_ms[iss['title']] = k
+                break
+
+ms_counters = {}
+for item in data.get('items', []):
+    s = item.get('status','')
+    t = item.get('title','')
+    sd = item.get('startDate')
+    item_id = item.get('id','')
+    if s != 'Done' and not sd and item_id:
+        ms_key = issue_ms.get(t)
+        if ms_key:
+            base_start, base_end = milestone_dates[ms_key]
+            if ms_key not in ms_counters:
+                ms_counters[ms_key] = 0
+            idx = ms_counters[ms_key]
+            ms_counters[ms_key] += 1
+            start_dt = datetime.strptime(base_start, '%Y-%m-%d') + timedelta(days=idx*4)
+            end_dt = start_dt + timedelta(days=3)
+            ms_end = datetime.strptime(base_end, '%Y-%m-%d')
+            if end_dt > ms_end: end_dt = ms_end
+            if start_dt > ms_end: start_dt = ms_end - timedelta(days=3)
+            start_str = start_dt.strftime('%Y-%m-%d')
+            end_str = end_dt.strftime('%Y-%m-%d')
+            subprocess.run(['gh','project','item-edit','--project-id',PROJECT_ID,'--id',item_id,'--field-id',START_FIELD,'--date',start_str], capture_output=True)
+            subprocess.run(['gh','project','item-edit','--project-id',PROJECT_ID,'--id',item_id,'--field-id',TARGET_FIELD,'--date',end_str], capture_output=True)
+            print(f'Set dates: {start_str} -> {end_str} | {t[:60]}')
+print('Done!')
+PYEOF
+```
+
+---
+
+## PR Metadata (MANDATORY on every PR)
+
+After creating a PR, apply the following:
+
+### Add Labels
+Choose from: `feature`, `bug`, `enhancement`, `refactor`, `testing`, `documentation`, `dx`, `ui/ux`, `performance`, `infra`, `seo`, `release`
+```bash
+gh pr edit <pr-number> --add-label "<label1>,<label2>"
+```
+
+### Assign Milestone (same as related Issue)
+```bash
+gh pr edit <pr-number> --milestone "<MILESTONE_TITLE>"
+```
+
+### Add to Project Board
+```bash
+gh project item-add 1 --owner shun2218-dev --url "https://github.com/shun2218-dev/asset-lens/pull/<pr-number>"
+```
+
+> ⚠️ **Do NOT skip any step.** All PRs must have: Labels ✅ Milestone ✅ Project ✅
+
+---
+
 ## Milestone Decision Guide
 
 | Milestone | Focus Area | Issue Types |
@@ -131,3 +246,4 @@ for item in data.get('items', []):
 | `v2.25 — Transaction UX` | Transaction workflow | Search, bulk, templates, split |
 | `v3.0 — Platform Expansion` | Major features | i18n, multi-currency, social login |
 | `v3.1 — Advanced Platform` | Advanced features | Voice, AI, shared expenses |
+

--- a/.agents/workflows/feature-development.md
+++ b/.agents/workflows/feature-development.md
@@ -123,8 +123,38 @@ gh pr create --base develop --head <branch-name> --title "<title>" --body "<desc
 Relates to #<issue-number>"
 ```
 
-## 7. Merge PR
-After review, merge the PR on GitHub (or via CLI):
+## 7. Self-Review (MANDATORY — see `/pr` skill)
+
+After PR creation and CI passing, perform a **senior engineer self-review** against the diff.
+
+> ⚠️ **This step is NOT optional.** Every PR must have a posted self-review comment before merge.
+
+1. **Analyze the diff**:
+```bash
+git diff develop
+```
+
+2. **Post review as PR comment** covering:
+   - ⚠️ Must Fix — security flaws, missing error handling, broken logic
+   - 💡 Suggestions — performance, naming, patterns
+   - 📝 Design rationale — explain non-obvious decisions
+   - Scalability considerations and follow-up suggestions
+
+```bash
+gh pr comment <PR-number> --body "<review content>"
+```
+
+3. **Fix any Must Fix items**, then re-run tests and push:
+```bash
+git add <fixed-files>
+git commit -m "fix: address self-review findings"
+git push origin <branch-name>
+```
+
+> Refer to the full `/pr` skill (`.agents/skills/pr-review/SKILL.md`) for review criteria, formatting guide, and decision framework.
+
+## 8. Merge PR
+After self-review is complete and CI passes, merge the PR:
 ```bash
 gh pr merge <pr-number> --merge --delete-branch
 ```
@@ -134,7 +164,7 @@ This will:
 
 > ℹ️ Issues are NOT auto-closed here — they are closed via `Closes #` in the **release PR** (merge to `main`).
 
-## 8. Clean Up Local Branch
+## 9. Clean Up Local Branch
 // turbo
 ```bash
 git checkout develop


### PR DESCRIPTION
## Summary

Two improvements to project management and code quality workflows:

### 1. project-sync skill additions
- **Bulk Date Assignment**: Python script to auto-assign Start/Target dates to all undated items based on their Milestone period
- **PR Metadata**: Mandatory Labels, Milestone, and Project Board linkage section
- **Milestone Periods table**: Quick reference for date ranges

### 2. feature-development workflow: mandatory Self-Review
- Insert **Step 7 (Self-Review)** between PR creation and merge
- Every PR must have a posted self-review comment covering: Must Fix, Suggestions, Design rationale
- Reference to full `/pr` skill for review criteria
- Renumber subsequent steps (Merge → Step 8, Clean Up → Step 9)

Relates to #176