### PR TITLE
refactor: migrate analysis actions to createSafeAction pattern

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -8,11 +8,21 @@ export const metadata: Metadata = {
 };
 
 import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
+import type { DashboardSummaryResult } from "@/app/actions/analysis/get-summary-with-comparison";
 import { getSummaryWithComparison } from "@/app/actions/analysis/get-summary-with-comparison";
 import { getBudgets } from "@/app/actions/budget/get";
 import { getCategories } from "@/app/actions/category/get";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { DashboardView } from "@/components/features/dashboard/dashboard-view";
+
+const EMPTY_DASHBOARD: DashboardSummaryResult = {
+  currentMonth: "",
+  summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+  previousSummary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+  categoryStats: [],
+  monthlyStats: [],
+  categoryExpenses: [],
+};
 
 interface DashboardPageProps {
   searchParams: { month?: string };
@@ -24,9 +34,7 @@ export default async function DashboardPage({
   const params = await searchParams;
   const currentMonth = params.month || format(new Date(), "yyyy-MM");
 
-  // 6 parallel calls → 4 parallel calls
-  // getSummaryWithComparison replaces 2x getSummary + categoryExpenses computation
-  const [dashboardSummary, recentData, storeRanking, categories, budgets] =
+  const [summaryResult, recentData, rankingResult, categories, budgets] =
     await Promise.all([
       getSummaryWithComparison(currentMonth),
       getTransaction(1, currentMonth),
@@ -35,6 +43,10 @@ export default async function DashboardPage({
       getBudgets(),
     ]);
 
+  const dashboardSummary = summaryResult.success
+    ? summaryResult.data
+    : { ...EMPTY_DASHBOARD, currentMonth };
+  const storeRanking = rankingResult.success ? rankingResult.data : [];
   const { data: recentTransactions } = recentData;
 
   return (

--- a/app/actions/analysis/get-store-ranking.ts
+++ b/app/actions/analysis/get-store-ranking.ts
@@ -2,23 +2,22 @@
 
 import { format } from "date-fns";
 import { desc, eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import { db } from "@/db";
 import { transaction } from "@/db/schema";
-import { auth } from "@/lib/auth";
+import { createSafeAction } from "@/lib/actions/safe-action";
 
-export async function getStoreRanking(month?: string) {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+export type StoreRankingItem = {
+  storeName: string;
+  totalAmount: number;
+};
 
-  if (!session) {
-    return [];
-  }
+export const getStoreRanking = createSafeAction<
+  string | undefined,
+  StoreRankingItem[]
+>(
+  async (month, userId) => {
+    const currentMonth = month || format(new Date(), "yyyy-MM");
 
-  const currentMonth = month || format(new Date(), "yyyy-MM");
-
-  try {
     const allTransactions = await db
       .select({
         storeName: transaction.storeName,
@@ -27,10 +26,9 @@ export async function getStoreRanking(month?: string) {
         isExpense: transaction.isExpense,
       })
       .from(transaction)
-      .where(eq(transaction.userId, session.user.id))
+      .where(eq(transaction.userId, userId))
       .orderBy(desc(transaction.date));
 
-    // Filter to current month + expenses only + has store name
     const monthlyExpenses = allTransactions.filter(
       (t) =>
         format(t.date, "yyyy-MM") === currentMonth &&
@@ -38,20 +36,16 @@ export async function getStoreRanking(month?: string) {
         t.storeName,
     );
 
-    // Aggregate by store name
     const storeMap = new Map<string, number>();
     for (const t of monthlyExpenses) {
       const current = storeMap.get(t.storeName!) || 0;
       storeMap.set(t.storeName!, current + t.amount);
     }
 
-    // Sort by total amount descending, take top 5
     return Array.from(storeMap.entries())
       .map(([storeName, totalAmount]) => ({ storeName, totalAmount }))
       .sort((a, b) => b.totalAmount - a.totalAmount)
       .slice(0, 5);
-  } catch (error) {
-    console.error("Failed to get store ranking:", error);
-    return [];
-  }
-}
+  },
+  { errorMessage: "Failed to get store ranking" },
+);

--- a/app/actions/analysis/get-summary-with-comparison.ts
+++ b/app/actions/analysis/get-summary-with-comparison.ts
@@ -2,15 +2,14 @@
 
 import { format, subMonths } from "date-fns";
 import { desc, eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import { db } from "@/db";
 import { transaction } from "@/db/schema";
+import { createSafeAction } from "@/lib/actions/safe-action";
 import {
   calculateCategoryBreakdown,
   calculateMonthlyTrends,
   calculatePeriodSummary,
 } from "@/lib/analysis/metrics";
-import { auth } from "@/lib/auth";
 import type { CategoryStats, MonthlyStats, SummaryStats } from "@/types";
 
 export type DashboardSummaryResult = {
@@ -28,52 +27,26 @@ const EMPTY_SUMMARY: SummaryStats = {
   balance: 0,
 };
 
-/**
- * Fetch dashboard summary data for both current and previous month
- * in a single database query, eliminating the duplicate getSummary calls.
- *
- * Also computes categoryExpenses server-side to avoid client-side
- * category ID resolution.
- */
-export async function getSummaryWithComparison(
-  month?: string,
-): Promise<DashboardSummaryResult> {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+export const getSummaryWithComparison = createSafeAction<
+  string | undefined,
+  DashboardSummaryResult
+>(
+  async (month, userId) => {
+    const currentMonth = month || format(new Date(), "yyyy-MM");
+    const [year, mon] = currentMonth.split("-").map(Number);
+    const prevDate = subMonths(new Date(year, mon - 1, 1), 1);
+    const previousMonth = format(prevDate, "yyyy-MM");
 
-  const currentMonth = month || format(new Date(), "yyyy-MM");
-  const [year, mon] = currentMonth.split("-").map(Number);
-  const prevDate = subMonths(new Date(year, mon - 1, 1), 1);
-  const previousMonth = format(prevDate, "yyyy-MM");
-
-  const emptyResult: DashboardSummaryResult = {
-    currentMonth,
-    summary: EMPTY_SUMMARY,
-    previousSummary: EMPTY_SUMMARY,
-    categoryStats: [],
-    monthlyStats: [],
-    categoryExpenses: [],
-  };
-
-  if (!session) {
-    return emptyResult;
-  }
-
-  try {
-    // Single DB query — filter both months in JS (same as original)
     const allTransactions = await db
       .select()
       .from(transaction)
-      .where(eq(transaction.userId, session.user.id))
+      .where(eq(transaction.userId, userId))
       .orderBy(desc(transaction.date));
 
-    // Current month data
     const currentTransactions = allTransactions.filter(
       (t) => format(t.date, "yyyy-MM") === currentMonth,
     );
 
-    // Previous month data — reuse same query result
     const prevTransactions = allTransactions.filter(
       (t) => format(t.date, "yyyy-MM") === previousMonth,
     );
@@ -83,7 +56,6 @@ export async function getSummaryWithComparison(
     const categoryStats = calculateCategoryBreakdown(currentTransactions);
     const monthlyStats = calculateMonthlyTrends(allTransactions);
 
-    // Build categoryExpenses server-side using categoryId from transactions
     const expenseMap = new Map<string, number>();
     for (const t of currentTransactions) {
       if (t.isExpense && t.categoryId) {
@@ -106,8 +78,6 @@ export async function getSummaryWithComparison(
       monthlyStats,
       categoryExpenses,
     };
-  } catch (error) {
-    console.error("Failed to fetch dashboard summary:", error);
-    return emptyResult;
-  }
-}
+  },
+  { errorMessage: "Failed to fetch dashboard summary" },
+);

--- a/app/actions/analysis/get-summary.test.ts
+++ b/app/actions/analysis/get-summary.test.ts
@@ -77,23 +77,17 @@ describe("getSummary", () => {
 
     const result = await getSummary("2024-01");
 
-    expect(result.currentMonth).toBe("2024-01");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
 
-    // Check filter: Only Jan transactions (id: 1, 2)
-    // Income: 5000, Expense: 1000, Balance: 4000
-    expect(result.summary.totalIncome).toBe(5000);
-    expect(result.summary.totalExpense).toBe(1000);
-    expect(result.summary.balance).toBe(4000);
-
-    // Check category stats (Jan only)
-    expect(result.categoryStats).toHaveLength(1); // Only 'food' expense
-    expect(result.categoryStats[0].category).toBe("cat-1"); // categoryId used
-
-    // Check monthly stats (All transactions)
-    // Jan: Income 5000, Expense 1000
-    // Feb: Income 0, Expense 2000
-    expect(result.monthlyStats).toHaveLength(2);
-    expect(result.monthlyStats).toEqual(
+    expect(result.data.currentMonth).toBe("2024-01");
+    expect(result.data.summary.totalIncome).toBe(5000);
+    expect(result.data.summary.totalExpense).toBe(1000);
+    expect(result.data.summary.balance).toBe(4000);
+    expect(result.data.categoryStats).toHaveLength(1);
+    expect(result.data.categoryStats[0].category).toBe("cat-1");
+    expect(result.data.monthlyStats).toHaveLength(2);
+    expect(result.data.monthlyStats).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           month: "2024-01",
@@ -105,14 +99,15 @@ describe("getSummary", () => {
     );
   });
 
-  it("should return empty structure if unauthorized", async () => {
-    // Override auth
+  it("should return error if unauthorized", async () => {
     const { auth } = await import("@/lib/auth");
     (auth.api.getSession as any).mockResolvedValueOnce(null);
 
     const result = await getSummary("2024-01");
 
-    expect(result.summary.totalIncome).toBe(0);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe("Please sign in to continue");
     expect(db.select).not.toHaveBeenCalled();
   });
 
@@ -123,6 +118,8 @@ describe("getSummary", () => {
 
     const result = await getSummary("2024-01");
 
-    expect(result.summary.totalIncome).toBe(0);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe("DB Error");
   });
 });

--- a/app/actions/analysis/get-summary.ts
+++ b/app/actions/analysis/get-summary.ts
@@ -2,44 +2,32 @@
 
 import { format } from "date-fns";
 import { desc, eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import { db } from "@/db";
 import { transaction } from "@/db/schema";
+import { createSafeAction } from "@/lib/actions/safe-action";
 import {
   calculateCategoryBreakdown,
   calculateMonthlyTrends,
   calculatePeriodSummary,
 } from "@/lib/analysis/metrics";
-import { auth } from "@/lib/auth";
 
-export async function getSummary(month?: string) {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+export type SummaryResult = {
+  currentMonth: string;
+  summary: { totalIncome: number; totalExpense: number; balance: number };
+  categoryStats: ReturnType<typeof calculateCategoryBreakdown>;
+  monthlyStats: ReturnType<typeof calculateMonthlyTrends>;
+};
 
-  // デフォルト値の定義
-  const currentMonth = month || format(new Date(), "yyyy-MM");
-  const emptyResult = {
-    currentMonth,
-    summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
-    categoryStats: [],
-    monthlyStats: [],
-  };
+export const getSummary = createSafeAction<string | undefined, SummaryResult>(
+  async (month, userId) => {
+    const currentMonth = month || format(new Date(), "yyyy-MM");
 
-  if (!session) {
-    return emptyResult;
-  }
-
-  try {
-    // グラフ用なので全件取得（limitなし）
-    // 必要なら where で「今年だけ」などに絞ることも可能
     const allTransactions = await db
       .select()
       .from(transaction)
-      .where(eq(transaction.userId, session.user.id))
+      .where(eq(transaction.userId, userId))
       .orderBy(desc(transaction.date));
 
-    // サマリーカード & 円グラフ用: 「指定した月」のデータのみ抽出
     const monthlyTransactions = allTransactions.filter((t) => {
       return format(t.date, "yyyy-MM") === currentMonth;
     });
@@ -54,9 +42,6 @@ export async function getSummary(month?: string) {
       categoryStats,
       monthlyStats,
     };
-  } catch (error) {
-    console.error("Failed to fetch summary:", error);
-    // エラー時の空データ
-    return emptyResult;
-  }
-}
+  },
+  { errorMessage: "Failed to fetch summary" },
+);


### PR DESCRIPTION
## Summary

Migrate all read-only analysis actions from manual `auth.api.getSession()` + ad-hoc error handling to the `createSafeAction` pattern for consistency.

### Changes
- **`get-summary.ts`**: `createSafeAction<string | undefined, SummaryResult>`
- **`get-summary-with-comparison.ts`**: `createSafeAction<string | undefined, DashboardSummaryResult>`
- **`get-store-ranking.ts`**: `createSafeAction<string | undefined, StoreRankingItem[]>`
- **Dashboard page**: Unwrap `SafeActionResult` with empty fallback on failure
- **Tests**: Updated to validate `{success, data/error}` shape

### Verification
- All 226 tests pass
- TypeScript compiles cleanly (`tsc --noEmit`)

Relates to #142