### PR TITLE
perf: add Suspense streaming for dashboard and transaction pages

### DIFF
--- a/app/(main)/dashboard/dashboard-content.tsx
+++ b/app/(main)/dashboard/dashboard-content.tsx
@@ -1,0 +1,64 @@
+import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
+import type { DashboardSummaryResult } from "@/app/actions/analysis/get-summary-with-comparison";
+import { getSummaryWithComparison } from "@/app/actions/analysis/get-summary-with-comparison";
+import { getBudgets } from "@/app/actions/budget/get";
+import { getCategories } from "@/app/actions/category/get";
+import { getTransaction } from "@/app/actions/transaction/get";
+import { DashboardView } from "@/components/features/dashboard/dashboard-view";
+
+const EMPTY_DASHBOARD: DashboardSummaryResult = {
+  currentMonth: "",
+  summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+  previousSummary: { totalIncome: 0, totalExpense: 0, balance: 0 },
+  categoryStats: [],
+  monthlyStats: [],
+  categoryExpenses: [],
+};
+
+interface DashboardContentProps {
+  currentMonth: string;
+}
+
+/**
+ * Async Server Component that fetches all dashboard data.
+ * Rendered inside a Suspense boundary so the page shell streams first.
+ */
+export async function DashboardContent({
+  currentMonth,
+}: DashboardContentProps) {
+  const [summaryResult, recentData, rankingResult, categories, budgets] =
+    await Promise.all([
+      getSummaryWithComparison(currentMonth),
+      getTransaction(1, currentMonth),
+      getStoreRanking(currentMonth),
+      getCategories(),
+      getBudgets(),
+    ]);
+
+  const dashboardSummary = summaryResult.success
+    ? summaryResult.data
+    : { ...EMPTY_DASHBOARD, currentMonth };
+  const storeRanking = rankingResult.success ? rankingResult.data : [];
+  const { data: recentTransactions } = recentData;
+
+  return (
+    <DashboardView
+      overview={{
+        summary: dashboardSummary.summary,
+        previousSummary: dashboardSummary.previousSummary,
+        currentMonth: dashboardSummary.currentMonth,
+      }}
+      charts={{
+        monthlyStats: dashboardSummary.monthlyStats,
+        categoryStats: dashboardSummary.categoryStats,
+        categories,
+      }}
+      widgets={{
+        recentTransactions,
+        storeRanking,
+        budgets,
+        categoryExpenses: dashboardSummary.categoryExpenses,
+      }}
+    />
+  );
+}

--- a/app/(main)/dashboard/loading.tsx
+++ b/app/(main)/dashboard/loading.tsx
@@ -1,25 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardSkeleton } from "@/components/layouts/page-skeletons";
 
 export default function DashboardLoading() {
-  return (
-    <div className="container mx-auto max-w-6xl px-4 md:px-8 py-10 space-y-8">
-      <div className="flex items-center justify-between">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-10 w-36 rounded-md" />
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-3">
-        <Skeleton className="h-28 rounded-xl" />
-        <Skeleton className="h-28 rounded-xl" />
-        <Skeleton className="h-28 rounded-xl" />
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-2">
-        <Skeleton className="h-72 rounded-xl" />
-        <Skeleton className="h-72 rounded-xl" />
-      </div>
-
-      <Skeleton className="h-64 rounded-xl" />
-    </div>
-  );
+  return <DashboardSkeleton />;
 }

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,27 +1,13 @@
 import { format } from "date-fns";
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { DashboardSkeleton } from "@/components/layouts/page-skeletons";
+import { DashboardContent } from "./dashboard-content";
 
 export const metadata: Metadata = {
   title: "ダッシュボード",
   description:
     "月次収支推移、カテゴリ別支出、予算進捗を一目で確認。家計の全体像を把握できるダッシュボード。",
-};
-
-import { getStoreRanking } from "@/app/actions/analysis/get-store-ranking";
-import type { DashboardSummaryResult } from "@/app/actions/analysis/get-summary-with-comparison";
-import { getSummaryWithComparison } from "@/app/actions/analysis/get-summary-with-comparison";
-import { getBudgets } from "@/app/actions/budget/get";
-import { getCategories } from "@/app/actions/category/get";
-import { getTransaction } from "@/app/actions/transaction/get";
-import { DashboardView } from "@/components/features/dashboard/dashboard-view";
-
-const EMPTY_DASHBOARD: DashboardSummaryResult = {
-  currentMonth: "",
-  summary: { totalIncome: 0, totalExpense: 0, balance: 0 },
-  previousSummary: { totalIncome: 0, totalExpense: 0, balance: 0 },
-  categoryStats: [],
-  monthlyStats: [],
-  categoryExpenses: [],
 };
 
 interface DashboardPageProps {
@@ -34,39 +20,9 @@ export default async function DashboardPage({
   const params = await searchParams;
   const currentMonth = params.month || format(new Date(), "yyyy-MM");
 
-  const [summaryResult, recentData, rankingResult, categories, budgets] =
-    await Promise.all([
-      getSummaryWithComparison(currentMonth),
-      getTransaction(1, currentMonth),
-      getStoreRanking(currentMonth),
-      getCategories(),
-      getBudgets(),
-    ]);
-
-  const dashboardSummary = summaryResult.success
-    ? summaryResult.data
-    : { ...EMPTY_DASHBOARD, currentMonth };
-  const storeRanking = rankingResult.success ? rankingResult.data : [];
-  const { data: recentTransactions } = recentData;
-
   return (
-    <DashboardView
-      overview={{
-        summary: dashboardSummary.summary,
-        previousSummary: dashboardSummary.previousSummary,
-        currentMonth: dashboardSummary.currentMonth,
-      }}
-      charts={{
-        monthlyStats: dashboardSummary.monthlyStats,
-        categoryStats: dashboardSummary.categoryStats,
-        categories,
-      }}
-      widgets={{
-        recentTransactions,
-        storeRanking,
-        budgets,
-        categoryExpenses: dashboardSummary.categoryExpenses,
-      }}
-    />
+    <Suspense fallback={<DashboardSkeleton />}>
+      <DashboardContent currentMonth={currentMonth} />
+    </Suspense>
   );
 }

--- a/app/(main)/transaction/page.tsx
+++ b/app/(main)/transaction/page.tsx
@@ -1,16 +1,14 @@
 import { format } from "date-fns";
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { TransactionSkeleton } from "@/components/layouts/page-skeletons";
+import { TransactionContent } from "./transaction-content";
 
 export const metadata: Metadata = {
   title: "取引一覧",
   description:
     "収入・支出の履歴を検索・フィルタ・ソート。取引データの一元管理と新規記録。",
 };
-
-import { getCategories } from "@/app/actions/category/get";
-import { getStores } from "@/app/actions/store/get";
-import { getTransaction } from "@/app/actions/transaction/get";
-import { TransactionPageView } from "@/components/features/transaction/transaction-page-view";
 
 interface TransactionsPage {
   searchParams: { month?: string };
@@ -20,25 +18,11 @@ export default async function TransactionPage({
   searchParams,
 }: TransactionsPage) {
   const params = await searchParams;
-  const initialPage = 1;
-  const now = new Date();
-  const defaultMonth = format(now, "yyyy-MM");
-  const currentMonth = params.month || defaultMonth;
+  const currentMonth = params.month || format(new Date(), "yyyy-MM");
 
-  const [transactionsData, categories, stores] = await Promise.all([
-    getTransaction(initialPage, currentMonth),
-    getCategories(),
-    getStores(),
-  ]);
-
-  const { data: transactions, metadata } = transactionsData;
   return (
-    <TransactionPageView
-      transactions={transactions}
-      metadata={metadata}
-      currentMonth={currentMonth}
-      categories={categories}
-      stores={stores}
-    />
+    <Suspense fallback={<TransactionSkeleton />}>
+      <TransactionContent currentMonth={currentMonth} />
+    </Suspense>
   );
 }

--- a/app/(main)/transaction/transaction-content.tsx
+++ b/app/(main)/transaction/transaction-content.tsx
@@ -1,0 +1,34 @@
+import { getCategories } from "@/app/actions/category/get";
+import { getStores } from "@/app/actions/store/get";
+import { getTransaction } from "@/app/actions/transaction/get";
+import { TransactionPageView } from "@/components/features/transaction/transaction-page-view";
+
+interface TransactionContentProps {
+  currentMonth: string;
+}
+
+/**
+ * Async Server Component that fetches all transaction data.
+ * Rendered inside a Suspense boundary so filters/shell stream first.
+ */
+export async function TransactionContent({
+  currentMonth,
+}: TransactionContentProps) {
+  const [transactionsData, categories, stores] = await Promise.all([
+    getTransaction(1, currentMonth),
+    getCategories(),
+    getStores(),
+  ]);
+
+  const { data: transactions, metadata } = transactionsData;
+
+  return (
+    <TransactionPageView
+      transactions={transactions}
+      metadata={metadata}
+      currentMonth={currentMonth}
+      categories={categories}
+      stores={stores}
+    />
+  );
+}

--- a/components/layouts/page-skeletons.tsx
+++ b/components/layouts/page-skeletons.tsx
@@ -1,0 +1,120 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function DashboardSkeleton() {
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-6 space-y-6 animate-pulse">
+      {/* Month Selector */}
+      <div className="flex items-center justify-center gap-4">
+        <Skeleton className="h-10 w-10 rounded-md" />
+        <Skeleton className="h-7 w-32" />
+        <Skeleton className="h-10 w-10 rounded-md" />
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border bg-card p-6 space-y-3">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="rounded-xl border bg-card p-6 space-y-3">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="rounded-xl border bg-card p-6 space-y-3">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+      </div>
+
+      {/* Charts */}
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-xl border bg-card p-6 space-y-4">
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-48 w-full rounded-lg" />
+        </div>
+        <div className="rounded-xl border bg-card p-6 space-y-4">
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-48 w-full rounded-lg" />
+        </div>
+      </div>
+
+      {/* Widgets */}
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-xl border bg-card p-6 space-y-3">
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+        <div className="rounded-xl border bg-card p-6 space-y-3">
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TransactionSkeleton() {
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-6 space-y-6 animate-pulse">
+      {/* Filters */}
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-24" />
+      </div>
+
+      {/* Transaction List */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="h-5 w-16" />
+        </div>
+        <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <Skeleton className="h-5 w-18" />
+        </div>
+        <div className="flex items-center justify-between rounded-lg border bg-card p-4">
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="h-5 w-20" />
+        </div>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center gap-2">
+        <Skeleton className="h-9 w-9" />
+        <Skeleton className="h-9 w-9" />
+        <Skeleton className="h-9 w-9" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implement React Server Component streaming with Suspense boundaries for dashboard and transaction pages.

### Changes
- **Dashboard**: Extract `DashboardContent` async Server Component, wrap with `<Suspense>`
- **Transaction**: Extract `TransactionContent` async Server Component, wrap with `<Suspense>`
- **Skeletons**: Centralized `page-skeletons.tsx` with layout-matching skeletons (no CLS)
- **loading.tsx**: Updated to use centralized skeleton components

### How it works
1. Page shell (metadata, Suspense boundary) renders immediately
2. Skeleton fallback shows while data fetches
3. Streamed content replaces skeleton progressively
4. Parallel `Promise.all()` preserved inside each content component

Relates to #127