### PR TITLE
refactor: migrate middleware.ts to proxy convention (#227)

### DIFF
--- a/.agents/rules/autonomy-policy.md
+++ b/.agents/rules/autonomy-policy.md
@@ -1,0 +1,13 @@
+# Autonomy Policy
+
+## Task Prioritization
+
+- **Do NOT ask the user for task order confirmation.** Decide the execution order autonomously based on dependency, complexity, and impact.
+- Prioritize: quick wins and blockers first, then features by dependency order.
+- If a decision has no significant user-facing trade-off, proceed without asking.
+
+## Decision Making
+
+- For implementation details (naming, file structure, library choice), make the call and proceed.
+- Only ask when there is a **genuine trade-off** that the user needs to weigh in on (e.g., breaking changes, UX decisions, cost implications).
+- If unsure, state your rationale briefly and proceed — the user will correct if needed.

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { middleware } from "./middleware";
+import { proxy } from "./proxy";
 
 // Mock NextResponse
 vi.mock("next/server", async () => {
@@ -45,80 +45,80 @@ function createRequest(pathname: string, country?: string): NextRequest {
   } as unknown as NextRequest;
 }
 
-describe("middleware", () => {
+describe("proxy", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
   it("should allow public paths from any country", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/", "CN"));
+    const result = proxy(createRequest("/", "CN"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow /login from any country", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/login", "RU"));
+    const result = proxy(createRequest("/login", "RU"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow /contact from any country", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/contact", "KP"));
+    const result = proxy(createRequest("/contact", "KP"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow /api/auth paths from any country", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/api/auth/callback", "CN"));
+    const result = proxy(createRequest("/api/auth/callback", "CN"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow whitelisted country access to authenticated routes", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/dashboard", "JP"));
+    const result = proxy(createRequest("/dashboard", "JP"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should block non-whitelisted country from /dashboard", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/dashboard", "CN"));
+    const result = proxy(createRequest("/dashboard", "CN"));
     expect(result).toBeInstanceOf(NextResponse);
   });
 
   it("should block non-whitelisted country from /transaction", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/transaction", "RU"));
+    const result = proxy(createRequest("/transaction", "RU"));
     expect(result).toBeInstanceOf(NextResponse);
   });
 
   it("should allow all countries when ALLOWED_COUNTRIES is *", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "*");
-    const result = middleware(createRequest("/dashboard", "CN"));
+    const result = proxy(createRequest("/dashboard", "CN"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow all countries when ALLOWED_COUNTRIES is not set", () => {
     // No env set = allow all
-    const result = middleware(createRequest("/dashboard", "CN"));
+    const result = proxy(createRequest("/dashboard", "CN"));
     expect(result).toMatchObject({ type: "next" });
   });
 
   it("should allow multiple countries from env", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP,US,GB");
-    const resultJP = middleware(createRequest("/dashboard", "JP"));
+    const resultJP = proxy(createRequest("/dashboard", "JP"));
     expect(resultJP).toMatchObject({ type: "next" });
 
-    const resultUS = middleware(createRequest("/dashboard", "US"));
+    const resultUS = proxy(createRequest("/dashboard", "US"));
     expect(resultUS).toMatchObject({ type: "next" });
 
-    const resultCN = middleware(createRequest("/dashboard", "CN"));
+    const resultCN = proxy(createRequest("/dashboard", "CN"));
     expect(resultCN).toBeInstanceOf(NextResponse);
   });
 
   it("should allow when no geo data is available", () => {
     vi.stubEnv("ALLOWED_COUNTRIES", "JP");
-    const result = middleware(createRequest("/dashboard"));
+    const result = proxy(createRequest("/dashboard"));
     expect(result).toMatchObject({ type: "next" });
   });
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -27,7 +27,7 @@ function isPublicPath(pathname: string): boolean {
   );
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const correlationId =


### PR DESCRIPTION
## Summary
Migrates the deprecated `middleware.ts` file convention to the new Next.js 16 `proxy.ts` convention.

## Changes
- Renamed `middleware.ts` → `proxy.ts` (via `@next/codemod`)
- Renamed exported function `middleware()` → `proxy()`
- Renamed `middleware.test.ts` → `proxy.test.ts` and updated all references
- Added autonomy policy agent rule

## Verification
- ✅ All 11 proxy tests pass
- ✅ `next build` successful — shows `ƒ Proxy (Middleware)` without deprecation warning
- ✅ No remaining references to `middleware` in codebase

Closes #227