### PR TITLE
feat: auto-suggest categories and store names in transaction form (#109)

### DIFF
--- a/app/actions/suggest/from-description.test.ts
+++ b/app/actions/suggest/from-description.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockDb = {
+  select: vi.fn(),
+  from: vi.fn(),
+  where: vi.fn(),
+  groupBy: vi.fn(),
+  orderBy: vi.fn(),
+  limit: vi.fn(),
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => {
+      mockDb.select();
+      return {
+        from: () => {
+          mockDb.from();
+          return {
+            where: () => {
+              mockDb.where();
+              return {
+                groupBy: () => {
+                  mockDb.groupBy();
+                  return {
+                    orderBy: () => {
+                      mockDb.orderBy();
+                      return {
+                        limit: () => {
+                          mockDb.limit();
+                          return Promise.resolve([
+                            {
+                              category: "food",
+                              storeName: "Lawson",
+                              count: 5,
+                            },
+                            {
+                              category: "food",
+                              storeName: "FamilyMart",
+                              count: 3,
+                            },
+                            {
+                              category: "daily",
+                              storeName: "Lawson",
+                              count: 2,
+                            },
+                          ]);
+                        },
+                      };
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi
+    .fn()
+    .mockResolvedValue(new Map([["x-correlation-id", "test-id"]])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("suggestFromDescription", () => {
+  it("should return empty results for short descriptions", async () => {
+    const { suggestFromDescription } = await import("./from-description");
+    const result = await suggestFromDescription("a");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.categories).toEqual([]);
+      expect(result.data.storeName).toBeNull();
+    }
+  });
+
+  it("should aggregate categories and find top store", async () => {
+    const { suggestFromDescription } = await import("./from-description");
+    const result = await suggestFromDescription("コンビニ");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.categories).toHaveLength(2);
+      expect(result.data.categories[0]).toEqual({
+        category: "food",
+        count: 8,
+      });
+      expect(result.data.categories[1]).toEqual({
+        category: "daily",
+        count: 2,
+      });
+      expect(result.data.storeName).toBe("Lawson");
+    }
+  });
+
+  it("should limit categories to 5 results", async () => {
+    const { suggestFromDescription } = await import("./from-description");
+    const result = await suggestFromDescription("test");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.categories.length).toBeLessThanOrEqual(5);
+    }
+  });
+});

--- a/app/actions/suggest/from-description.ts
+++ b/app/actions/suggest/from-description.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { and, desc, eq, ilike, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { transaction } from "@/db/schema";
+import { createSafeAction } from "@/lib/actions/safe-action";
+
+interface SuggestionResult {
+  categories: Array<{ category: string; count: number }>;
+  storeName: string | null;
+}
+
+export const suggestFromDescription = createSafeAction<
+  string,
+  SuggestionResult
+>(
+  async (description, userId) => {
+    if (!description || description.length < 2) {
+      return { categories: [], storeName: null };
+    }
+
+    const results = await db
+      .select({
+        category: transaction.category,
+        storeName: transaction.storeName,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(transaction)
+      .where(
+        and(
+          eq(transaction.userId, userId),
+          ilike(transaction.description, `%${description}%`),
+        ),
+      )
+      .groupBy(transaction.category, transaction.storeName)
+      .orderBy(desc(sql`count(*)`))
+      .limit(10);
+
+    const categoryMap = new Map<string, number>();
+    let topStoreName: string | null = null;
+    let topStoreCount = 0;
+
+    for (const row of results) {
+      const existing = categoryMap.get(row.category) ?? 0;
+      categoryMap.set(row.category, existing + row.count);
+
+      if (row.storeName && row.count > topStoreCount) {
+        topStoreName = row.storeName;
+        topStoreCount = row.count;
+      }
+    }
+
+    const categories = Array.from(categoryMap.entries())
+      .map(([category, count]) => ({ category, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return { categories, storeName: topStoreName };
+  },
+  {
+    errorMessage: "Failed to suggest categories",
+    rateLimit: "read",
+  },
+);

--- a/components/features/suggestion/category-suggestion-badges.tsx
+++ b/components/features/suggestion/category-suggestion-badges.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import type { SelectCategory } from "@/db/schema";
+import { cn } from "@/lib/utils";
+
+interface CategorySuggestionBadgesProps {
+  suggestions: Array<{ category: string; count: number }>;
+  categories: SelectCategory[];
+  currentValue: string;
+  onSelect: (slug: string) => void;
+}
+
+export function CategorySuggestionBadges({
+  suggestions,
+  categories,
+  currentValue,
+  onSelect,
+}: CategorySuggestionBadgesProps) {
+  if (suggestions.length === 0) return null;
+
+  const getCategoryName = (slug: string) => {
+    const cat = categories.find((c) => c.slug === slug);
+    return cat?.name ?? slug;
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+      <Sparkles className="h-3 w-3 text-amber-500 shrink-0" />
+      {suggestions.map(({ category }) => (
+        <button
+          key={category}
+          type="button"
+          onClick={() => onSelect(category)}
+          className={cn(
+            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors",
+            "border border-border hover:bg-accent hover:text-accent-foreground",
+            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
+            category === currentValue &&
+              "bg-primary text-primary-foreground border-primary hover:bg-primary/90 hover:text-primary-foreground",
+          )}
+        >
+          {getCategoryName(category)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/features/transaction/transaction-form.tsx
+++ b/components/features/transaction/transaction-form.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { format } from "date-fns";
-import { CalendarIcon, Camera, Loader2 } from "lucide-react";
+import { CalendarIcon, Camera, Loader2, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { createStore } from "@/app/actions/store/create";
 import { CategorySelect } from "@/components/features/category/category-select";
 import { StoreSelect } from "@/components/features/store/store-select";
+import { CategorySuggestionBadges } from "@/components/features/suggestion/category-suggestion-badges";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -24,6 +25,7 @@ import {
 } from "@/components/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { SelectCategory, SelectStore } from "@/db/schema";
+import { useDescriptionSuggestions } from "@/hooks/use-description-suggestions";
 import { useTransactionForm } from "@/hooks/use-transaction-form";
 import { useSession } from "@/lib/auth/client";
 import { cn } from "@/lib/utils";
@@ -72,6 +74,13 @@ export function TransactionForm({
   });
 
   const isExpense = form.watch("isExpense");
+  const {
+    categories: suggestedCategories,
+    storeName: suggestedStore,
+    isLoading: isSuggesting,
+    fetchSuggestions,
+    clearSuggestions,
+  } = useDescriptionSuggestions();
 
   // Fix: Hydration mismatch prevention
   const [mounted, setMounted] = useState(false);
@@ -291,8 +300,40 @@ export function TransactionForm({
                     isExpense ? "コンビニ、スーパーなど" : "給料、賞与など"
                   }
                   {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    fetchSuggestions(e.target.value);
+                  }}
                 />
               </FormControl>
+              {suggestedCategories.length > 0 && (
+                <CategorySuggestionBadges
+                  suggestions={suggestedCategories}
+                  categories={categories}
+                  currentValue={form.getValues("category")}
+                  onSelect={(slug) => {
+                    form.setValue("category", slug, {
+                      shouldValidate: true,
+                      shouldDirty: true,
+                    });
+                  }}
+                />
+              )}
+              {suggestedStore && !form.getValues("storeName") && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    form.setValue("storeName", suggestedStore, {
+                      shouldValidate: true,
+                      shouldDirty: true,
+                    });
+                  }}
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <Sparkles className="h-3 w-3 text-amber-500" />
+                  店舗: {suggestedStore} を設定
+                </button>
+              )}
               <FormMessage />
             </FormItem>
           )}

--- a/hooks/use-description-suggestions.ts
+++ b/hooks/use-description-suggestions.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { suggestFromDescription } from "@/app/actions/suggest/from-description";
+
+interface CategorySuggestion {
+  category: string;
+  count: number;
+}
+
+interface SuggestionState {
+  categories: CategorySuggestion[];
+  storeName: string | null;
+  isLoading: boolean;
+}
+
+export function useDescriptionSuggestions() {
+  const [state, setState] = useState<SuggestionState>({
+    categories: [],
+    storeName: null,
+    isLoading: false,
+  });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchSuggestions = useCallback((description: string) => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!description || description.length < 2) {
+      setState({ categories: [], storeName: null, isLoading: false });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: true }));
+
+    debounceRef.current = setTimeout(async () => {
+      const result = await suggestFromDescription(description);
+      if (result.success) {
+        setState({
+          categories: result.data.categories,
+          storeName: result.data.storeName,
+          isLoading: false,
+        });
+      } else {
+        setState({ categories: [], storeName: null, isLoading: false });
+      }
+    }, 300);
+  }, []);
+
+  const clearSuggestions = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    setState({ categories: [], storeName: null, isLoading: false });
+  }, []);
+
+  return {
+    ...state,
+    fetchSuggestions,
+    clearSuggestions,
+  };
+}


### PR DESCRIPTION
## Summary
Adds intelligent auto-suggestion for categories and store names in the transaction form based on the user's transaction history. When typing in the description field, the system suggests the most frequently used categories and associated stores.

## Changes

### Server Action
- `app/actions/suggest/from-description.ts`: SQL-based suggestion using `ilike` on past transactions, grouped by category and store name, sorted by frequency

### Hooks
- `hooks/use-description-suggestions.ts`: Debounced (300ms) client hook that calls the server action and manages suggestion state

### Components
- `components/features/suggestion/category-suggestion-badges.tsx`: Clickable badge UI with sparkle icon for suggested categories
- Updated `transaction-form.tsx`: Integrated description field onChange → suggestion fetch → badge display + store suggestion link

### Tests
- 3 new unit tests for `suggestFromDescription` action

## Technical Details
- No external AI — rule-based inference from user's own data only
- Rate limited via `read` tier (60 req/min)
- Suggestions are candidates only — user always has final selection
- `ilike` search with aggregation for Top-5 categories

Relates to #109