### PR TITLE
feat: add transaction templates with CRUD and quick-add (#132)

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getBudgets } from "@/app/actions/budget/get";
+import { getTemplates } from "@/app/actions/template";
 
 export const metadata: Metadata = {
   title: "設定",
@@ -13,12 +14,14 @@ import { SettingsView } from "@/components/features/settings/settings-view";
 import { requireAuth } from "@/lib/auth/guard";
 
 export default async function SettingsPage() {
-  const [session, subscriptions, budgets, categories] = await Promise.all([
-    requireAuth(),
-    getSubscription(),
-    getBudgets(),
-    getCategories(),
-  ]);
+  const [session, subscriptions, budgets, categories, templates] =
+    await Promise.all([
+      requireAuth(),
+      getSubscription(),
+      getBudgets(),
+      getCategories(),
+      getTemplates(),
+    ]);
 
   return (
     <SettingsView
@@ -26,6 +29,7 @@ export default async function SettingsPage() {
       subscriptions={subscriptions}
       budgets={budgets}
       categories={categories}
+      templates={templates}
     />
   );
 }

--- a/app/(main)/transaction/transaction-content.tsx
+++ b/app/(main)/transaction/transaction-content.tsx
@@ -1,5 +1,6 @@
 import { getCategories } from "@/app/actions/category/get";
 import { getStores } from "@/app/actions/store/get";
+import { getTemplates } from "@/app/actions/template";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { TransactionPageView } from "@/components/features/transaction/transaction-page-view";
 
@@ -14,11 +15,14 @@ interface TransactionContentProps {
 export async function TransactionContent({
   currentMonth,
 }: TransactionContentProps) {
-  const [transactionsResult, categories, stores] = await Promise.all([
-    getTransaction({ page: 1, month: currentMonth }),
-    getCategories(),
-    getStores(),
-  ]);
+  const [transactionsResult, categories, stores, templates] = await Promise.all(
+    [
+      getTransaction({ page: 1, month: currentMonth }),
+      getCategories(),
+      getStores(),
+      getTemplates(),
+    ],
+  );
 
   const { data: transactions, metadata } = transactionsResult.success
     ? transactionsResult.data
@@ -40,6 +44,7 @@ export async function TransactionContent({
       currentMonth={currentMonth}
       categories={categories}
       stores={stores}
+      templates={templates}
     />
   );
 }

--- a/app/actions/template/index.test.ts
+++ b/app/actions/template/index.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockReturning = vi.fn();
+const mockDelete = vi.fn();
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockSelectResult: Array<{ id: string }> = [];
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+    insert: () => {
+      mockInsert();
+      return {
+        values: (v: unknown) => {
+          mockValues(v);
+          return {
+            returning: () => {
+              mockReturning();
+              return Promise.resolve([{ id: "new-id" }]);
+            },
+          };
+        },
+      };
+    },
+    delete: () => {
+      mockDelete();
+      return {
+        where: () => Promise.resolve(),
+      };
+    },
+    update: () => {
+      mockUpdate();
+      return {
+        set: (v: unknown) => {
+          mockSet(v);
+          return {
+            where: () => Promise.resolve(),
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: "user-123" },
+      }),
+    },
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi
+    .fn()
+    .mockResolvedValue(new Map([["x-correlation-id", "test-id"]])),
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
+  unstable_cache: (fn: () => unknown) => fn,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("template actions", () => {
+  it("should create a template and return id", async () => {
+    const { createTemplate } = await import("./index");
+    const result = await createTemplate({
+      name: "Rent",
+      amount: 80000,
+      category: "housing",
+      isExpense: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("new-id");
+    }
+  });
+
+  it("should delete a template", async () => {
+    const { deleteTemplate } = await import("./index");
+    const result = await deleteTemplate("template-id-1");
+    expect(result.success).toBe(true);
+  });
+
+  it("should update a template", async () => {
+    const { updateTemplate } = await import("./index");
+    const result = await updateTemplate({
+      id: "template-id-1",
+      name: "Updated Rent",
+      amount: 85000,
+      category: "housing",
+      isExpense: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should increment template usage", async () => {
+    const { incrementTemplateUsage } = await import("./index");
+    const result = await incrementTemplateUsage("template-id-1");
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/actions/template/index.ts
+++ b/app/actions/template/index.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { and, desc, eq, sql } from "drizzle-orm";
+import { unstable_cache, updateTag } from "next/cache";
+import { headers } from "next/headers";
+import { db } from "@/db";
+import { transactionTemplate } from "@/db/schema";
+import { createSafeAction } from "@/lib/actions/safe-action";
+import { auth } from "@/lib/auth";
+
+const MAX_TEMPLATES = 20;
+
+function templateTag(userId: string) {
+  return `templates-${userId}`;
+}
+
+export async function getTemplates() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return [];
+  }
+
+  return getTemplatesCached(session.user.id)();
+}
+
+function getTemplatesCached(userId: string) {
+  return unstable_cache(
+    async () => {
+      return db
+        .select()
+        .from(transactionTemplate)
+        .where(eq(transactionTemplate.userId, userId))
+        .orderBy(desc(transactionTemplate.usageCount));
+    },
+    [`templates-${userId}`],
+    {
+      tags: [templateTag(userId)],
+      revalidate: 3600,
+    },
+  );
+}
+
+interface CreateTemplateInput {
+  name: string;
+  amount: number;
+  description?: string;
+  storeName?: string;
+  category: string;
+  isExpense: boolean;
+}
+
+export const createTemplate = createSafeAction<
+  CreateTemplateInput,
+  { id: string }
+>(
+  async (input, userId) => {
+    const existing = await db
+      .select({ id: transactionTemplate.id })
+      .from(transactionTemplate)
+      .where(eq(transactionTemplate.userId, userId));
+
+    if (existing.length >= MAX_TEMPLATES) {
+      throw new Error(
+        `Maximum ${MAX_TEMPLATES} templates allowed. Delete unused templates first.`,
+      );
+    }
+
+    const [result] = await db
+      .insert(transactionTemplate)
+      .values({
+        userId,
+        name: input.name,
+        amount: input.amount,
+        description: input.description ?? "",
+        storeName: input.storeName ?? null,
+        category: input.category,
+        isExpense: input.isExpense,
+      })
+      .returning({ id: transactionTemplate.id });
+
+    updateTag(templateTag(userId));
+    return { id: result.id };
+  },
+  { errorMessage: "Failed to create template" },
+);
+
+interface UpdateTemplateInput {
+  id: string;
+  name: string;
+  amount: number;
+  description?: string;
+  storeName?: string;
+  category: string;
+  isExpense: boolean;
+}
+
+export const updateTemplate = createSafeAction<UpdateTemplateInput, void>(
+  async (input, userId) => {
+    await db
+      .update(transactionTemplate)
+      .set({
+        name: input.name,
+        amount: input.amount,
+        description: input.description ?? "",
+        storeName: input.storeName ?? null,
+        category: input.category,
+        isExpense: input.isExpense,
+      })
+      .where(
+        and(
+          eq(transactionTemplate.id, input.id),
+          eq(transactionTemplate.userId, userId),
+        ),
+      );
+
+    updateTag(templateTag(userId));
+  },
+  { errorMessage: "Failed to update template" },
+);
+
+export const deleteTemplate = createSafeAction<string, void>(
+  async (id, userId) => {
+    await db
+      .delete(transactionTemplate)
+      .where(
+        and(
+          eq(transactionTemplate.id, id),
+          eq(transactionTemplate.userId, userId),
+        ),
+      );
+
+    updateTag(templateTag(userId));
+  },
+  { errorMessage: "Failed to delete template" },
+);
+
+export const incrementTemplateUsage = createSafeAction<string, void>(
+  async (id, userId) => {
+    await db
+      .update(transactionTemplate)
+      .set({
+        usageCount: sql`${transactionTemplate.usageCount} + 1`,
+      })
+      .where(
+        and(
+          eq(transactionTemplate.id, id),
+          eq(transactionTemplate.userId, userId),
+        ),
+      );
+
+    updateTag(templateTag(userId));
+  },
+  { errorMessage: "Failed to update template usage" },
+);

--- a/components/features/settings/settings-view.stories.tsx
+++ b/components/features/settings/settings-view.stories.tsx
@@ -58,6 +58,7 @@ export const Default: Story = {
   args: {
     session: mockSession,
     subscriptions: mockSubscriptions,
+    templates: [],
   },
 };
 
@@ -65,5 +66,6 @@ export const Empty: Story = {
   args: {
     session: mockSession,
     subscriptions: [],
+    templates: [],
   },
 };

--- a/components/features/settings/settings-view.tsx
+++ b/components/features/settings/settings-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, FileText, Shield, Store } from "lucide-react";
+import { AlertTriangle, FileText, Shield, Store, Zap } from "lucide-react";
 import { PasskeySettings } from "@/components/features/auth/passkey-settings";
 import { PasswordSettings } from "@/components/features/auth/password-settings";
 import { BudgetSettings } from "@/components/features/budget/budget-settings";
@@ -10,6 +10,7 @@ import { ExportButton } from "@/components/features/settings/export-button";
 import { ImportButton } from "@/components/features/settings/import-button";
 import { StoreNameMigrationTool } from "@/components/features/settings/store-name-migration-tool";
 import { SubscriptionList } from "@/components/features/subscription/subscription-list";
+import { TemplateManager } from "@/components/features/template/template-manager";
 import {
   Card,
   CardContent,
@@ -19,7 +20,12 @@ import {
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { SelectBudget, SelectCategory, subscription } from "@/db/schema";
+import type {
+  SelectBudget,
+  SelectCategory,
+  SelectTransactionTemplate,
+  subscription,
+} from "@/db/schema";
 
 type SelectSubscription = typeof subscription.$inferSelect;
 
@@ -38,6 +44,7 @@ interface SettingsViewProps {
   subscriptions: SelectSubscription[];
   budgets: BudgetWithCategory[];
   categories: SelectCategory[];
+  templates: SelectTransactionTemplate[];
 }
 
 export function SettingsView({
@@ -45,6 +52,7 @@ export function SettingsView({
   subscriptions,
   budgets,
   categories,
+  templates,
 }: SettingsViewProps) {
   return (
     <main className="container max-w-5xl px-4 py-10 pb-24 md:pb-10 space-y-8 mx-auto min-h-screen">
@@ -59,10 +67,11 @@ export function SettingsView({
 
       <Tabs defaultValue="account" className="space-y-6">
         <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
-          <TabsList className="inline-flex w-auto min-w-full sm:grid sm:w-full sm:grid-cols-5 lg:w-175">
+          <TabsList className="inline-flex w-auto min-w-full sm:grid sm:w-full sm:grid-cols-6 lg:w-210">
             <TabsTrigger value="account">アカウント</TabsTrigger>
             <TabsTrigger value="category">カテゴリ</TabsTrigger>
             <TabsTrigger value="budget">予算</TabsTrigger>
+            <TabsTrigger value="template">テンプレート</TabsTrigger>
             <TabsTrigger value="data">データ管理</TabsTrigger>
             <TabsTrigger value="subscription">サブスク</TabsTrigger>
           </TabsList>
@@ -116,6 +125,24 @@ export function SettingsView({
         {/* --- タブ: 予算管理 --- */}
         <TabsContent value="budget" className="space-y-6">
           <BudgetSettings budgets={budgets} categories={categories} />
+        </TabsContent>
+
+        {/* --- タブ: テンプレート管理 --- */}
+        <TabsContent value="template" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Zap className="h-5 w-5" />
+                取引テンプレート
+              </CardTitle>
+              <CardDescription>
+                よく使う取引をテンプレートとして保存しておくと、ワンタップで入力できます。
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <TemplateManager templates={templates} categories={categories} />
+            </CardContent>
+          </Card>
         </TabsContent>
 
         {/* --- タブ: データ管理 --- */}

--- a/components/features/template/template-manager.tsx
+++ b/components/features/template/template-manager.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { Edit2, Plus, Trash2 } from "lucide-react";
+import { useCallback, useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  createTemplate,
+  deleteTemplate,
+  updateTemplate,
+} from "@/app/actions/template";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { SelectCategory, SelectTransactionTemplate } from "@/db/schema";
+
+interface TemplateManagerProps {
+  templates: SelectTransactionTemplate[];
+  categories: SelectCategory[];
+}
+
+interface TemplateFormData {
+  name: string;
+  amount: number;
+  description: string;
+  storeName: string;
+  category: string;
+  isExpense: boolean;
+}
+
+const emptyForm: TemplateFormData = {
+  name: "",
+  amount: 0,
+  description: "",
+  storeName: "",
+  category: "food",
+  isExpense: true,
+};
+
+export function TemplateManager({
+  templates: initialTemplates,
+  categories,
+}: TemplateManagerProps) {
+  const [templates, setTemplates] =
+    useState<SelectTransactionTemplate[]>(initialTemplates);
+  const [open, setOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formData, setFormData] = useState<TemplateFormData>(emptyForm);
+  const [isPending, startTransition] = useTransition();
+
+  const handleOpen = useCallback((template?: SelectTransactionTemplate) => {
+    if (template) {
+      setEditingId(template.id);
+      setFormData({
+        name: template.name,
+        amount: template.amount,
+        description: template.description ?? "",
+        storeName: template.storeName ?? "",
+        category: template.category,
+        isExpense: template.isExpense,
+      });
+    } else {
+      setEditingId(null);
+      setFormData(emptyForm);
+    }
+    setOpen(true);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    startTransition(async () => {
+      if (editingId) {
+        const result = await updateTemplate({
+          id: editingId,
+          ...formData,
+          storeName: formData.storeName || undefined,
+        });
+        if (result.success) {
+          setTemplates((prev) =>
+            prev.map((t) =>
+              t.id === editingId
+                ? {
+                    ...t,
+                    ...formData,
+                    storeName: formData.storeName || null,
+                  }
+                : t,
+            ),
+          );
+          toast.success("テンプレートを更新しました");
+        } else {
+          toast.error(result.error);
+        }
+      } else {
+        const result = await createTemplate({
+          ...formData,
+          storeName: formData.storeName || undefined,
+        });
+        if (result.success) {
+          setTemplates((prev) => [
+            ...prev,
+            {
+              id: result.data.id,
+              userId: "",
+              ...formData,
+              storeName: formData.storeName || null,
+              usageCount: 0,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ]);
+          toast.success("テンプレートを作成しました");
+        } else {
+          toast.error(result.error);
+        }
+      }
+      setOpen(false);
+    });
+  }, [editingId, formData]);
+
+  const handleDelete = useCallback((id: string) => {
+    startTransition(async () => {
+      const result = await deleteTemplate(id);
+      if (result.success) {
+        setTemplates((prev) => prev.filter((t) => t.id !== id));
+        toast.success("テンプレートを削除しました");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }, []);
+
+  const expenseCategories = categories.filter((c) => c.type === "expense");
+  const incomeCategories = categories.filter((c) => c.type === "income");
+  const filteredCategories = formData.isExpense
+    ? expenseCategories
+    : incomeCategories;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">
+          テンプレート ({templates.length}/20)
+        </h3>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button
+              size="sm"
+              onClick={() => handleOpen()}
+              disabled={templates.length >= 20}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              追加
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {editingId ? "テンプレート編集" : "テンプレート作成"}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 pt-2">
+              <div>
+                <Label>テンプレート名</Label>
+                <Input
+                  placeholder="家賃、電気代など"
+                  value={formData.name}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, name: e.target.value }))
+                  }
+                />
+              </div>
+              <Tabs
+                value={formData.isExpense ? "expense" : "income"}
+                onValueChange={(v) =>
+                  setFormData((p) => ({
+                    ...p,
+                    isExpense: v === "expense",
+                    category: v === "expense" ? "food" : "salary",
+                  }))
+                }
+              >
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger
+                    value="expense"
+                    className="data-[state=active]:bg-red-700 data-[state=active]:text-white"
+                  >
+                    支出
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="income"
+                    className="data-[state=active]:bg-blue-700 data-[state=active]:text-white"
+                  >
+                    収入
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label>金額</Label>
+                  <Input
+                    type="number"
+                    placeholder="0"
+                    value={formData.amount || ""}
+                    onChange={(e) =>
+                      setFormData((p) => ({
+                        ...p,
+                        amount: Number(e.target.value),
+                      }))
+                    }
+                  />
+                </div>
+                <div>
+                  <Label>カテゴリ</Label>
+                  <Select
+                    value={formData.category}
+                    onValueChange={(v) =>
+                      setFormData((p) => ({ ...p, category: v }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {filteredCategories.map((c) => (
+                        <SelectItem key={c.id} value={c.slug}>
+                          {c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div>
+                <Label>店舗名（任意）</Label>
+                <Input
+                  placeholder="コンビニ、スーパーなど"
+                  value={formData.storeName}
+                  onChange={(e) =>
+                    setFormData((p) => ({
+                      ...p,
+                      storeName: e.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div>
+                <Label>用途・メモ（任意）</Label>
+                <Input
+                  placeholder="毎月の固定費"
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData((p) => ({
+                      ...p,
+                      description: e.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <Button
+                className="w-full"
+                onClick={handleSubmit}
+                disabled={isPending || !formData.name || !formData.amount}
+              >
+                {editingId ? "更新" : "作成"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {templates.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          テンプレートがありません。よく使う取引を登録しましょう。
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {templates.map((template) => (
+            <div
+              key={template.id}
+              className="flex items-center justify-between rounded-lg border p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium truncate">{template.name}</span>
+                  <span
+                    className={`text-xs px-1.5 py-0.5 rounded ${template.isExpense ? "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400" : "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400"}`}
+                  >
+                    {template.isExpense ? "支出" : "収入"}
+                  </span>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  ¥{template.amount.toLocaleString()} ·{" "}
+                  {categories.find((c) => c.slug === template.category)?.name ??
+                    template.category}
+                  {template.usageCount > 0 && (
+                    <span className="ml-2">({template.usageCount}回使用)</span>
+                  )}
+                </div>
+              </div>
+              <div className="flex gap-1 shrink-0">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => handleOpen(template)}
+                >
+                  <Edit2 className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => handleDelete(template.id)}
+                  disabled={isPending}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/template/template-quick-add.tsx
+++ b/components/features/template/template-quick-add.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Zap } from "lucide-react";
+import { useCallback, useState, useTransition } from "react";
+import { incrementTemplateUsage } from "@/app/actions/template";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { SelectTransactionTemplate } from "@/db/schema";
+
+interface TemplateQuickAddProps {
+  templates: SelectTransactionTemplate[];
+  onSelect: (template: SelectTransactionTemplate) => void;
+}
+
+export function TemplateQuickAdd({
+  templates,
+  onSelect,
+}: TemplateQuickAddProps) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSelect = useCallback(
+    (template: SelectTransactionTemplate) => {
+      onSelect(template);
+      setOpen(false);
+      startTransition(async () => {
+        await incrementTemplateUsage(template.id);
+      });
+    },
+    [onSelect],
+  );
+
+  if (templates.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <Zap className="h-3.5 w-3.5 text-amber-500" />
+          テンプレート
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-2" align="start">
+        <div className="space-y-1 max-h-64 overflow-y-auto">
+          {templates.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => handleSelect(t)}
+              disabled={isPending}
+              className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent transition-colors"
+            >
+              <div className="font-medium">{t.name}</div>
+              <div className="text-xs text-muted-foreground">
+                ¥{t.amount.toLocaleString()} · {t.isExpense ? "支出" : "収入"}
+              </div>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/features/transaction/transaction-page-view.stories.tsx
+++ b/components/features/transaction/transaction-page-view.stories.tsx
@@ -108,6 +108,7 @@ export const Default: Story = {
     currentMonth: "2024-01",
     categories: mockCategories,
     stores: [],
+    templates: [],
   },
 };
 
@@ -124,5 +125,6 @@ export const Empty: Story = {
     currentMonth: "2024-01",
     categories: mockCategories,
     stores: [],
+    templates: [],
   },
 };

--- a/components/features/transaction/transaction-page-view.tsx
+++ b/components/features/transaction/transaction-page-view.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useCallback, useState } from "react";
+import { TemplateQuickAdd } from "@/components/features/template/template-quick-add";
 import { TransactionForm } from "@/components/features/transaction/transaction-form";
 import { TransactionList } from "@/components/features/transaction/transaction-list";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,6 +22,7 @@ import type {
   SelectCategory,
   SelectStore,
   SelectTransaction,
+  SelectTransactionTemplate,
 } from "@/db/schema";
 import type { TransactionMetadata } from "@/types";
 
@@ -29,6 +32,7 @@ interface TransactionPageViewProps {
   currentMonth: string;
   categories: SelectCategory[];
   stores: SelectStore[];
+  templates: SelectTransactionTemplate[];
 }
 
 export function TransactionPageView({
@@ -37,7 +41,29 @@ export function TransactionPageView({
   currentMonth,
   categories,
   stores,
+  templates,
 }: TransactionPageViewProps) {
+  const [templateData, setTemplateData] = useState<{
+    amount: number;
+    description: string;
+    storeName?: string;
+    category: string;
+    isExpense: boolean;
+  } | null>(null);
+
+  const handleTemplateSelect = useCallback(
+    (template: SelectTransactionTemplate) => {
+      setTemplateData({
+        amount: template.amount,
+        description: template.description ?? "",
+        storeName: template.storeName ?? undefined,
+        category: template.category,
+        isExpense: template.isExpense,
+      });
+    },
+    [],
+  );
+
   return (
     <main className="container mx-auto max-w-6xl px-4 py-10 pb-24 md:pb-10 space-y-8 min-h-screen">
       <div>
@@ -52,7 +78,13 @@ export function TransactionPageView({
         <div className="md:col-span-1">
           <Card>
             <CardHeader>
-              <CardTitle>新規入力</CardTitle>
+              <div className="flex items-center justify-between">
+                <CardTitle>新規入力</CardTitle>
+                <TemplateQuickAdd
+                  templates={templates}
+                  onSelect={handleTemplateSelect}
+                />
+              </div>
             </CardHeader>
             <CardContent>
               <Tabs defaultValue="single" className="w-full">
@@ -61,7 +93,26 @@ export function TransactionPageView({
                   <TabsTrigger value="bulk">一括入力</TabsTrigger>
                 </TabsList>
                 <TabsContent value="single">
-                  <TransactionForm categories={categories} stores={stores} />
+                  <TransactionForm
+                    categories={categories}
+                    stores={stores}
+                    initialData={
+                      templateData
+                        ? {
+                            userId: "",
+                            amount: templateData.amount,
+                            description: templateData.description,
+                            storeName: templateData.storeName,
+                            category: templateData.category,
+                            date: new Date(),
+                            isExpense: templateData.isExpense,
+                          }
+                        : undefined
+                    }
+                    key={
+                      templateData ? JSON.stringify(templateData) : "default"
+                    }
+                  />
                 </TabsContent>
                 <TabsContent value="bulk">
                   <BulkTransactionForm

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -256,6 +256,7 @@ export const userRelations = relations(user, ({ many }) => ({
   transactions: many(transaction),
   subscriptions: many(subscription),
   stores: many(store),
+  transactionTemplates: many(transactionTemplate),
 }));
 
 export const storeRelations = relations(store, ({ one }) => ({
@@ -333,3 +334,45 @@ export const budgetRelations = relations(budget, ({ one }) => ({
     references: [category.id],
   }),
 }));
+
+export const transactionTemplate = pgTable(
+  "transaction_template",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    amount: integer("amount").notNull(),
+    description: text("description").default(""),
+    storeName: text("store_name"),
+    category: text("category").notNull(),
+    isExpense: boolean("is_expense").default(true).notNull(),
+    usageCount: integer("usage_count").default(0).notNull(),
+    createdAt: timestamp("created_at", { precision: 0, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { precision: 0, withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("template_userId_idx").on(table.userId)],
+);
+
+export type SelectTransactionTemplate = InferSelectModel<
+  typeof transactionTemplate
+>;
+export type InsertTransactionTemplate = InferInsertModel<
+  typeof transactionTemplate
+>;
+
+export const transactionTemplateRelations = relations(
+  transactionTemplate,
+  ({ one }) => ({
+    user: one(user, {
+      fields: [transactionTemplate.userId],
+      references: [user.id],
+    }),
+  }),
+);

--- a/drizzle/0013_loose_johnny_storm.sql
+++ b/drizzle/0013_loose_johnny_storm.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "transaction_template" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"amount" integer NOT NULL,
+	"description" text DEFAULT '',
+	"store_name" text,
+	"category" text NOT NULL,
+	"is_expense" boolean DEFAULT true NOT NULL,
+	"usage_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp (0) with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "transaction_template" ADD CONSTRAINT "transaction_template_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "template_userId_idx" ON "transaction_template" USING btree ("user_id");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1168 @@
+{
+  "id": "8109dcaf-57cc-4ec1-8f38-7c75e2017572",
+  "prevId": "a32e2b76-d4c6-4852-9137-6964bdde65b7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget": {
+      "name": "budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_userId_categoryId_idx": {
+          "name": "budget_userId_categoryId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_user_id_user_id_fk": {
+          "name": "budget_user_id_user_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_category_id_category_id_fk": {
+          "name": "budget_category_id_category_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'expense'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_userId_idx": {
+          "name": "category_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_userId_user_id_fk": {
+          "name": "category_userId_user_id_fk",
+          "tableFrom": "category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store": {
+      "name": "store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_userId_idx": {
+          "name": "store_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JPY'"
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_payment_date": {
+          "name": "next_payment_date",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_userId_idx": {
+          "name": "subscription_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_userId_idx": {
+          "name": "transactions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_date_idx": {
+          "name": "transactions_userId_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_storeName_idx": {
+          "name": "transactions_userId_storeName_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_user_id_user_id_fk": {
+          "name": "transaction_user_id_user_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_category_id_category_id_fk": {
+          "name": "transaction_category_id_category_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_template": {
+      "name": "transaction_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_template_user_id_user_id_fk": {
+          "name": "transaction_template_user_id_user_id_fk",
+          "tableFrom": "transaction_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1774829535140,
       "tag": "0012_flippant_diamondback",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1775103565494,
+      "tag": "0013_loose_johnny_storm",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Allow users to save frequently used transactions as templates for one-tap entry. Supports full CRUD management in settings and quick-add popover in transaction form.

## Changes

### Database
- New `transaction_template` table with `usage_count` for frequency sorting
- Migration `0013_loose_johnny_storm.sql`

### Server Actions (`app/actions/template/`)
- `getTemplates`: Cached list sorted by usage frequency
- `createTemplate`: With 20-template limit per user
- `updateTemplate` / `deleteTemplate`: CRUD operations
- `incrementTemplateUsage`: Tracks usage for frequency sorting

### UI Components
- `TemplateManager`: Full CRUD UI in settings (dialog form for create/edit)
- `TemplateQuickAdd`: Popover in transaction page header for one-tap entry
- Settings page gets new 'template' tab
- Transaction form auto-fills from template selection

### Tests
- 4 unit tests for template CRUD actions
- Updated Storybook stories

## Technical Details
- Uses `updateTag` (Next.js 16 API) for cache invalidation
- Templates limited to 20 per user
- Usage count tracks template popularity

Relates to #132