### PR TITLE
feat: add debounced search with URL persistence (#234)

### DIFF
--- a/components/features/transaction/transaction-filters.stories.tsx
+++ b/components/features/transaction/transaction-filters.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { TransactionFilters } from "./transaction-filters";
 
 const meta: Meta<typeof TransactionFilters> = {
@@ -75,12 +75,13 @@ export const TypeSearchQuery: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    const searchInput = canvas.getByPlaceholderText("内容で検索...");
+    const searchInput = canvas.getByPlaceholderText("内容・店舗名で検索...");
     await userEvent.type(searchInput, "lunch");
 
-    // TransactionFilters is a controlled component — value comes from props.
-    // We verify that onFiltersChange was called with the search query.
-    await expect(args.onFiltersChange).toHaveBeenCalled();
+    // Debounced at 300ms — wait for the callback to fire
+    await waitFor(() => expect(args.onFiltersChange).toHaveBeenCalled(), {
+      timeout: 1000,
+    });
   },
 };
 

--- a/components/features/transaction/transaction-filters.tsx
+++ b/components/features/transaction/transaction-filters.tsx
@@ -2,6 +2,7 @@
 
 import { format } from "date-fns";
 import { CalendarIcon, RotateCcw, Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
@@ -40,17 +41,34 @@ export function TransactionFilters({
     !!filters.dateTo ||
     !!filters.searchQuery;
 
+  const [searchText, setSearchText] = useState(filters.searchQuery || "");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchText(value);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onFiltersChange({ ...filters, searchQuery: value || undefined });
+      }, 300);
+    },
+    [filters, onFiltersChange],
+  );
+
+  // Sync local state when filters are reset externally
+  useEffect(() => {
+    setSearchText(filters.searchQuery || "");
+  }, [filters.searchQuery]);
+
   return (
     <div className="space-y-3">
       {/* Search */}
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
-          placeholder="内容で検索..."
-          value={filters.searchQuery || ""}
-          onChange={(e) =>
-            onFiltersChange({ ...filters, searchQuery: e.target.value })
-          }
+          placeholder="内容・店舗名で検索..."
+          value={searchText}
+          onChange={(e) => handleSearchChange(e.target.value)}
           className="pl-9"
         />
       </div>

--- a/components/features/transaction/transaction-list.tsx
+++ b/components/features/transaction/transaction-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Loader2, Receipt } from "lucide-react";
+import { Loader2, Receipt, SearchX } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState, useTransition } from "react";
 import { getTransaction } from "@/app/actions/transaction/get";
 import { PaginationControl } from "@/components/features/transaction/pagination-control";
@@ -49,7 +50,15 @@ export function TransactionList({
   const [transactions, setTransactions] = useState(initialData);
   const [metadata, setMetadata] = useState(initialMetadata);
   const [isPending, startTransition] = useTransition();
-  const [filters, setFilters] = useState<TransactionFilterParams>({});
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Initialize search from URL
+  const initialSearch = searchParams.get("q") || undefined;
+  const [filters, setFilters] = useState<TransactionFilterParams>({
+    searchQuery: initialSearch,
+  });
   const [sort, setSort] = useState<TransactionSortParams>({});
 
   // 月が変わったらデータを初期化（リセット）
@@ -100,7 +109,16 @@ export function TransactionList({
   // フィルタ変更時
   const handleFiltersChange = (newFilters: TransactionFilterParams) => {
     setFilters(newFilters);
-    fetchData(1, newFilters, sort); // Reset to page 1
+    fetchData(1, newFilters, sort);
+
+    // Sync search query to URL
+    const params = new URLSearchParams(searchParams.toString());
+    if (newFilters.searchQuery) {
+      params.set("q", newFilters.searchQuery);
+    } else {
+      params.delete("q");
+    }
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   // ソート変更時
@@ -114,6 +132,9 @@ export function TransactionList({
     setFilters({});
     setSort({});
     fetchData(1, {}, {});
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("q");
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (
@@ -177,10 +198,16 @@ export function TransactionList({
               <TableCell colSpan={6} className="text-center h-40">
                 <div className="flex flex-col items-center gap-2 py-4">
                   <div className="p-3 bg-muted/50 rounded-full">
-                    <Receipt className="h-6 w-6 text-muted-foreground/60" />
+                    {filters.searchQuery ? (
+                      <SearchX className="h-6 w-6 text-muted-foreground/60" />
+                    ) : (
+                      <Receipt className="h-6 w-6 text-muted-foreground/60" />
+                    )}
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    まだ取引がありません。左のフォームから記録しましょう
+                    {filters.searchQuery
+                      ? `「${filters.searchQuery}」に一致する取引が見つかりません`
+                      : "まだ取引がありません。左のフォームから記録しましょう"}
                   </p>
                 </div>
               </TableCell>


### PR DESCRIPTION
## Summary
Improve the existing transaction search by adding debounce, URL persistence, and better UX.

## Changes

### TransactionFilters
- Add 300ms debounce to search input (prevents excessive server requests)
- Update placeholder: `内容・店舗名で検索...`
- Manage local search state separately from debounced callback

### TransactionList
- Initialize search from URL `?q=` parameter on load
- Sync search query to URL on filter change (shareable links)
- Add search-specific empty state with `SearchX` icon and query text

### Storybook
- Fix placeholder text in filter story
- Add `waitFor` in TypeSearchQuery test to handle debounce timing

## Technical Notes
- No new dependencies — uses existing `ilike` server action
- Debounce uses `useRef` + `setTimeout` (no external library)
- URL sync uses `router.replace` with `scroll: false`

Relates to #234