### PR TITLE
feat: add transaction duplicate detection and merge (#147)

### DIFF
--- a/app/(main)/transaction/transaction-content.tsx
+++ b/app/(main)/transaction/transaction-content.tsx
@@ -1,4 +1,5 @@
 import { getCategories } from "@/app/actions/category/get";
+import { getDuplicates } from "@/app/actions/duplicate";
 import { getStores } from "@/app/actions/store/get";
 import { getTemplates } from "@/app/actions/template";
 import { getTransaction } from "@/app/actions/transaction/get";
@@ -15,14 +16,14 @@ interface TransactionContentProps {
 export async function TransactionContent({
   currentMonth,
 }: TransactionContentProps) {
-  const [transactionsResult, categories, stores, templates] = await Promise.all(
-    [
+  const [transactionsResult, categories, stores, templates, duplicatesResult] =
+    await Promise.all([
       getTransaction({ page: 1, month: currentMonth }),
       getCategories(),
       getStores(),
       getTemplates(),
-    ],
-  );
+      getDuplicates(),
+    ]);
 
   const { data: transactions, metadata } = transactionsResult.success
     ? transactionsResult.data
@@ -45,6 +46,7 @@ export async function TransactionContent({
       categories={categories}
       stores={stores}
       templates={templates}
+      duplicates={duplicatesResult.success ? duplicatesResult.data : []}
     />
   );
 }

--- a/app/actions/duplicate/index.test.ts
+++ b/app/actions/duplicate/index.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db", () => {
+  // biome-ignore lint/suspicious/noThenProperty: required for thenable proxy
+  const thenable = { then: (r: (v: unknown[]) => void) => r([]) };
+  const chain = () =>
+    new Proxy(thenable, {
+      get: (_t, prop) => {
+        if (prop === "then") return thenable.then;
+        return (..._a: unknown[]) => chain();
+      },
+    });
+  return { db: chain() };
+});
+
+vi.mock("@/db/schema", () => ({
+  transaction: { id: "id", userId: "user_id" },
+  dismissedDuplicate: {
+    transactionId1: "transaction_id_1",
+    transactionId2: "transaction_id_2",
+    userId: "user_id",
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/safe-action", () => ({
+  createSafeAction: (
+    handler: (input: unknown, userId: string) => Promise<unknown>,
+  ) => {
+    return async (input: unknown) => {
+      try {
+        const result = await handler(input, "user-123");
+        return { success: true, data: result };
+      } catch {
+        return { success: false, error: "error" };
+      }
+    };
+  },
+}));
+
+describe("duplicate detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should export getDuplicates", async () => {
+    const { getDuplicates } = await import("./index");
+    expect(getDuplicates).toBeDefined();
+    expect(typeof getDuplicates).toBe("function");
+  });
+
+  it("should export mergeDuplicates", async () => {
+    const { mergeDuplicates } = await import("./index");
+    expect(mergeDuplicates).toBeDefined();
+    expect(typeof mergeDuplicates).toBe("function");
+  });
+
+  it("should export dismissDuplicate", async () => {
+    const { dismissDuplicate } = await import("./index");
+    expect(dismissDuplicate).toBeDefined();
+    expect(typeof dismissDuplicate).toBe("function");
+  });
+});

--- a/app/actions/duplicate/index.ts
+++ b/app/actions/duplicate/index.ts
@@ -1,0 +1,199 @@
+"use server";
+
+import { and, eq, or } from "drizzle-orm";
+import { updateTag } from "next/cache";
+import { db } from "@/db";
+import { dismissedDuplicate, transaction } from "@/db/schema";
+import { createSafeAction } from "@/lib/actions/safe-action";
+
+/**
+ * Simple Levenshtein distance implementation.
+ * No external library needed — store names are short strings.
+ */
+function levenshtein(a: string, b: string): number {
+  const la = a.length;
+  const lb = b.length;
+  const dp: number[][] = Array.from({ length: la + 1 }, (_, i) =>
+    Array.from({ length: lb + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+  );
+  for (let i = 1; i <= la; i++) {
+    for (let j = 1; j <= lb; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return dp[la][lb];
+}
+
+export type DuplicateCandidate = {
+  transaction1: {
+    id: string;
+    amount: number;
+    description: string | null;
+    storeName: string | null;
+    category: string;
+    date: Date;
+  };
+  transaction2: {
+    id: string;
+    amount: number;
+    description: string | null;
+    storeName: string | null;
+    category: string;
+    date: Date;
+  };
+};
+
+/**
+ * Detect duplicate transactions for the current user.
+ * Criteria: same amount + date within 24h + similar store name (Levenshtein ≤ 2).
+ */
+export const getDuplicates = createSafeAction<void, DuplicateCandidate[]>(
+  async (_input, userId) => {
+    // Get all transactions for this user
+    const allTransactions = await db
+      .select({
+        id: transaction.id,
+        amount: transaction.amount,
+        description: transaction.description,
+        storeName: transaction.storeName,
+        category: transaction.category,
+        date: transaction.date,
+      })
+      .from(transaction)
+      .where(eq(transaction.userId, userId))
+      .orderBy(transaction.date);
+
+    // Get dismissed pairs
+    const dismissed = await db
+      .select({
+        id1: dismissedDuplicate.transactionId1,
+        id2: dismissedDuplicate.transactionId2,
+      })
+      .from(dismissedDuplicate)
+      .where(eq(dismissedDuplicate.userId, userId));
+
+    const dismissedSet = new Set(dismissed.map((d) => `${d.id1}:${d.id2}`));
+    const isDismissed = (id1: string, id2: string) => {
+      const [a, b] = [id1, id2].sort();
+      return dismissedSet.has(`${a}:${b}`);
+    };
+
+    const duplicates: DuplicateCandidate[] = [];
+
+    for (let i = 0; i < allTransactions.length; i++) {
+      for (let j = i + 1; j < allTransactions.length; j++) {
+        const t1 = allTransactions[i];
+        const t2 = allTransactions[j];
+
+        // Same amount
+        if (t1.amount !== t2.amount) continue;
+
+        // Within 24 hours
+        const timeDiff = Math.abs(t1.date.getTime() - t2.date.getTime());
+        if (timeDiff > 24 * 60 * 60 * 1000) continue;
+
+        // Similar store name (Levenshtein ≤ 2)
+        const store1 = (t1.storeName || "").toLowerCase();
+        const store2 = (t2.storeName || "").toLowerCase();
+        // If both have no store, check description instead
+        if (!t1.storeName && !t2.storeName) {
+          const desc1 = (t1.description || "").toLowerCase();
+          const desc2 = (t2.description || "").toLowerCase();
+          if (levenshtein(desc1, desc2) > 2) continue;
+        } else if (levenshtein(store1, store2) > 2) {
+          continue;
+        }
+
+        // Check if dismissed
+        if (isDismissed(t1.id, t2.id)) continue;
+
+        duplicates.push({ transaction1: t1, transaction2: t2 });
+      }
+    }
+
+    return duplicates;
+  },
+  { errorMessage: "Failed to detect duplicates" },
+);
+
+/**
+ * Merge two duplicate transactions: keep the one with more data, delete the other.
+ */
+export const mergeDuplicates = createSafeAction<
+  { keepId: string; deleteId: string },
+  { success: boolean }
+>(
+  async (input, userId) => {
+    const { keepId, deleteId } = input;
+
+    // Verify both transactions belong to this user
+    const [keepTx, deleteTx] = await Promise.all([
+      db
+        .select()
+        .from(transaction)
+        .where(and(eq(transaction.id, keepId), eq(transaction.userId, userId)))
+        .then((r) => r[0]),
+      db
+        .select()
+        .from(transaction)
+        .where(
+          and(eq(transaction.id, deleteId), eq(transaction.userId, userId)),
+        )
+        .then((r) => r[0]),
+    ]);
+
+    if (!keepTx || !deleteTx) {
+      return { success: false, error: "Transaction not found" } as never;
+    }
+
+    // Delete the duplicate
+    await db
+      .delete(transaction)
+      .where(and(eq(transaction.id, deleteId), eq(transaction.userId, userId)));
+
+    // Also clean up any dismissed pairs involving the deleted transaction
+    await db
+      .delete(dismissedDuplicate)
+      .where(
+        and(
+          eq(dismissedDuplicate.userId, userId),
+          or(
+            eq(dismissedDuplicate.transactionId1, deleteId),
+            eq(dismissedDuplicate.transactionId2, deleteId),
+          ),
+        ),
+      );
+
+    updateTag("transactions");
+    return { success: true };
+  },
+  { errorMessage: "Failed to merge duplicates" },
+);
+
+/**
+ * Dismiss a duplicate pair so it won't be flagged again.
+ */
+export const dismissDuplicate = createSafeAction<
+  { transactionId1: string; transactionId2: string },
+  { success: boolean }
+>(
+  async (input, userId) => {
+    // Store IDs in sorted order for consistent lookup
+    const [id1, id2] = [input.transactionId1, input.transactionId2].sort();
+
+    await db.insert(dismissedDuplicate).values({
+      userId,
+      transactionId1: id1,
+      transactionId2: id2,
+    });
+
+    updateTag("duplicates");
+    return { success: true };
+  },
+  { errorMessage: "Failed to dismiss duplicate" },
+);

--- a/components/features/duplicate/duplicate-banner.tsx
+++ b/components/features/duplicate/duplicate-banner.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { AlertTriangle, Check, X } from "lucide-react";
+import { useCallback, useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  type DuplicateCandidate,
+  dismissDuplicate,
+  mergeDuplicates,
+} from "@/app/actions/duplicate";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface DuplicateBannerProps {
+  initialDuplicates: DuplicateCandidate[];
+}
+
+export function DuplicateBanner({ initialDuplicates }: DuplicateBannerProps) {
+  const [duplicates, setDuplicates] =
+    useState<DuplicateCandidate[]>(initialDuplicates);
+  const [isPending, startTransition] = useTransition();
+
+  const handleMerge = useCallback(
+    (keepId: string, deleteId: string, index: number) => {
+      startTransition(async () => {
+        const result = await mergeDuplicates({ keepId, deleteId });
+        if (result.success) {
+          setDuplicates((prev) => prev.filter((_, i) => i !== index));
+          toast.success("取引をマージしました");
+        } else {
+          toast.error("マージに失敗しました");
+        }
+      });
+    },
+    [],
+  );
+
+  const handleDismiss = useCallback(
+    (transactionId1: string, transactionId2: string, index: number) => {
+      startTransition(async () => {
+        const result = await dismissDuplicate({
+          transactionId1,
+          transactionId2,
+        });
+        if (result.success) {
+          setDuplicates((prev) => prev.filter((_, i) => i !== index));
+          toast.success("重複候補を除外しました");
+        } else {
+          toast.error("除外に失敗しました");
+        }
+      });
+    },
+    [],
+  );
+
+  if (duplicates.length === 0) return null;
+
+  const formatAmount = (amount: number) =>
+    new Intl.NumberFormat("ja-JP", {
+      style: "currency",
+      currency: "JPY",
+    }).format(amount);
+
+  const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat("ja-JP", {
+      month: "short",
+      day: "numeric",
+    }).format(date);
+
+  return (
+    <Card className="border-amber-500/50 bg-amber-500/5">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-amber-500" />
+          <CardTitle className="text-base">重複の可能性がある取引</CardTitle>
+          <Badge variant="secondary" className="ml-auto">
+            {duplicates.length}件
+          </Badge>
+        </div>
+        <CardDescription>
+          同じ金額・日付・店舗の取引が見つかりました。マージまたは除外してください。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {duplicates.map((dup, index) => (
+          <div
+            key={`${dup.transaction1.id}-${dup.transaction2.id}`}
+            className="flex flex-col gap-2 rounded-lg border p-3 bg-background"
+          >
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="space-y-1">
+                <p className="font-medium">
+                  {dup.transaction1.description ||
+                    dup.transaction1.storeName ||
+                    "—"}
+                </p>
+                <p className="text-muted-foreground">
+                  {formatDate(dup.transaction1.date)} ·{" "}
+                  {formatAmount(dup.transaction1.amount)}
+                </p>
+                {dup.transaction1.storeName && (
+                  <p className="text-xs text-muted-foreground">
+                    🏪 {dup.transaction1.storeName}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-1">
+                <p className="font-medium">
+                  {dup.transaction2.description ||
+                    dup.transaction2.storeName ||
+                    "—"}
+                </p>
+                <p className="text-muted-foreground">
+                  {formatDate(dup.transaction2.date)} ·{" "}
+                  {formatAmount(dup.transaction2.amount)}
+                </p>
+                {dup.transaction2.storeName && (
+                  <p className="text-xs text-muted-foreground">
+                    🏪 {dup.transaction2.storeName}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending}
+                onClick={() =>
+                  handleDismiss(dup.transaction1.id, dup.transaction2.id, index)
+                }
+              >
+                <X className="mr-1 h-3 w-3" />
+                除外
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending}
+                onClick={() =>
+                  handleMerge(dup.transaction1.id, dup.transaction2.id, index)
+                }
+              >
+                <Check className="mr-1 h-3 w-3" />
+                左を残す
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending}
+                onClick={() =>
+                  handleMerge(dup.transaction2.id, dup.transaction1.id, index)
+                }
+              >
+                <Check className="mr-1 h-3 w-3" />
+                右を残す
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/features/transaction/transaction-page-view.stories.tsx
+++ b/components/features/transaction/transaction-page-view.stories.tsx
@@ -109,6 +109,7 @@ export const Default: Story = {
     categories: mockCategories,
     stores: [],
     templates: [],
+    duplicates: [],
   },
 };
 
@@ -126,5 +127,6 @@ export const Empty: Story = {
     categories: mockCategories,
     stores: [],
     templates: [],
+    duplicates: [],
   },
 };

--- a/components/features/transaction/transaction-page-view.tsx
+++ b/components/features/transaction/transaction-page-view.tsx
@@ -2,6 +2,8 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useState } from "react";
+import type { DuplicateCandidate } from "@/app/actions/duplicate";
+import { DuplicateBanner } from "@/components/features/duplicate/duplicate-banner";
 import { TemplateQuickAdd } from "@/components/features/template/template-quick-add";
 import { TransactionForm } from "@/components/features/transaction/transaction-form";
 import { TransactionList } from "@/components/features/transaction/transaction-list";
@@ -33,6 +35,7 @@ interface TransactionPageViewProps {
   categories: SelectCategory[];
   stores: SelectStore[];
   templates: SelectTransactionTemplate[];
+  duplicates: DuplicateCandidate[];
 }
 
 export function TransactionPageView({
@@ -42,6 +45,7 @@ export function TransactionPageView({
   categories,
   stores,
   templates,
+  duplicates,
 }: TransactionPageViewProps) {
   const [templateData, setTemplateData] = useState<{
     amount: number;
@@ -72,6 +76,10 @@ export function TransactionPageView({
           収支の記録と履歴の確認・管理
         </p>
       </div>
+
+      {duplicates.length > 0 && (
+        <DuplicateBanner initialDuplicates={duplicates} />
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* 左側: 入力フォーム (1カラム) */}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -257,6 +257,7 @@ export const userRelations = relations(user, ({ many }) => ({
   subscriptions: many(subscription),
   stores: many(store),
   transactionTemplates: many(transactionTemplate),
+  dismissedDuplicates: many(dismissedDuplicate),
 }));
 
 export const storeRelations = relations(store, ({ one }) => ({
@@ -372,6 +373,49 @@ export const transactionTemplateRelations = relations(
   ({ one }) => ({
     user: one(user, {
       fields: [transactionTemplate.userId],
+      references: [user.id],
+    }),
+  }),
+);
+
+export const dismissedDuplicate = pgTable(
+  "dismissed_duplicate",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    transactionId1: uuid("transaction_id_1")
+      .notNull()
+      .references(() => transaction.id, { onDelete: "cascade" }),
+    transactionId2: uuid("transaction_id_2")
+      .notNull()
+      .references(() => transaction.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { precision: 0, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("dismissed_dup_userId_idx").on(table.userId),
+    index("dismissed_dup_pair_idx").on(
+      table.transactionId1,
+      table.transactionId2,
+    ),
+  ],
+);
+
+export type SelectDismissedDuplicate = InferSelectModel<
+  typeof dismissedDuplicate
+>;
+export type InsertDismissedDuplicate = InferInsertModel<
+  typeof dismissedDuplicate
+>;
+
+export const dismissedDuplicateRelations = relations(
+  dismissedDuplicate,
+  ({ one }) => ({
+    user: one(user, {
+      fields: [dismissedDuplicate.userId],
       references: [user.id],
     }),
   }),

--- a/drizzle/0014_absurd_gladiator.sql
+++ b/drizzle/0014_absurd_gladiator.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "dismissed_duplicate" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"transaction_id_1" uuid NOT NULL,
+	"transaction_id_2" uuid NOT NULL,
+	"created_at" timestamp (0) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "dismissed_duplicate" ADD CONSTRAINT "dismissed_duplicate_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dismissed_duplicate" ADD CONSTRAINT "dismissed_duplicate_transaction_id_1_transaction_id_fk" FOREIGN KEY ("transaction_id_1") REFERENCES "public"."transaction"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dismissed_duplicate" ADD CONSTRAINT "dismissed_duplicate_transaction_id_2_transaction_id_fk" FOREIGN KEY ("transaction_id_2") REFERENCES "public"."transaction"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "dismissed_dup_userId_idx" ON "dismissed_duplicate" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "dismissed_dup_pair_idx" ON "dismissed_duplicate" USING btree ("transaction_id_1","transaction_id_2");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1290 @@
+{
+  "id": "997c5df6-08f0-47ec-8ab3-5f911cb69cbb",
+  "prevId": "8109dcaf-57cc-4ec1-8f38-7c75e2017572",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget": {
+      "name": "budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_userId_categoryId_idx": {
+          "name": "budget_userId_categoryId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_user_id_user_id_fk": {
+          "name": "budget_user_id_user_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_category_id_category_id_fk": {
+          "name": "budget_category_id_category_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'expense'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_userId_idx": {
+          "name": "category_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_userId_user_id_fk": {
+          "name": "category_userId_user_id_fk",
+          "tableFrom": "category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_duplicate": {
+      "name": "dismissed_duplicate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id_1": {
+          "name": "transaction_id_1",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id_2": {
+          "name": "transaction_id_2",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_dup_userId_idx": {
+          "name": "dismissed_dup_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_dup_pair_idx": {
+          "name": "dismissed_dup_pair_idx",
+          "columns": [
+            {
+              "expression": "transaction_id_1",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_id_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_duplicate_user_id_user_id_fk": {
+          "name": "dismissed_duplicate_user_id_user_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dismissed_duplicate_transaction_id_1_transaction_id_fk": {
+          "name": "dismissed_duplicate_transaction_id_1_transaction_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "transaction",
+          "columnsFrom": [
+            "transaction_id_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dismissed_duplicate_transaction_id_2_transaction_id_fk": {
+          "name": "dismissed_duplicate_transaction_id_2_transaction_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "transaction",
+          "columnsFrom": [
+            "transaction_id_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store": {
+      "name": "store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_userId_idx": {
+          "name": "store_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JPY'"
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_payment_date": {
+          "name": "next_payment_date",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_userId_idx": {
+          "name": "subscription_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_userId_idx": {
+          "name": "transactions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_date_idx": {
+          "name": "transactions_userId_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_storeName_idx": {
+          "name": "transactions_userId_storeName_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_user_id_user_id_fk": {
+          "name": "transaction_user_id_user_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_category_id_category_id_fk": {
+          "name": "transaction_category_id_category_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_template": {
+      "name": "transaction_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_template_user_id_user_id_fk": {
+          "name": "transaction_template_user_id_user_id_fk",
+          "tableFrom": "transaction_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775103565494,
       "tag": "0013_loose_johnny_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1775107658426,
+      "tag": "0014_absurd_gladiator",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Detect and flag potentially duplicate transactions, allowing users to merge or dismiss them.

## Changes

### Database
- New `dismissed_duplicate` table to track dismissed pairs
- Migration `0014_absurd_gladiator.sql`

### Server Actions (`app/actions/duplicate/`)
- `getDuplicates`: Detects duplicates using same amount + 24h window + Levenshtein ≤ 2
- `mergeDuplicates`: Keeps one transaction, deletes the duplicate
- `dismissDuplicate`: Marks pair as not-duplicate (sorted IDs for consistency)
- Inline Levenshtein implementation (no external dependency)

### UI
- `DuplicateBanner`: Amber warning card with side-by-side comparison
- Shows duplicate count badge
- Merge buttons (keep left/right) and dismiss button
- Integrated above the transaction grid

### Tests
- 3 unit tests for action exports
- Updated Storybook stories with `duplicates` prop

## Technical Notes
- Levenshtein implemented inline (~30 lines) — no `fastest-levenshtein` needed since store names are short
- Dismissed pairs stored with sorted IDs to prevent duplicates in the dismissed table
- Detection runs on page load (server component)

Relates to #147