### PR TITLE
feat: add contact inquiry management dashboard

### DIFF
--- a/app/(main)/admin/inquiries/[id]/page.tsx
+++ b/app/(main)/admin/inquiries/[id]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getInquiryById } from "@/app/actions/contact/get";
+import { InquiryDetailView } from "@/components/features/admin/inquiry-detail-view";
+import { requireAdmin } from "@/lib/auth/admin-guard";
+
+export const metadata: Metadata = {
+  title: "お問い合わせ詳細",
+};
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AdminInquiryDetailPage({ params }: PageProps) {
+  await requireAdmin();
+
+  const { id } = await params;
+  const inquiry = await getInquiryById(id);
+
+  if (!inquiry) {
+    notFound();
+  }
+
+  return (
+    <main className="container mx-auto max-w-6xl px-4 py-8 md:py-12">
+      <InquiryDetailView inquiry={inquiry} />
+    </main>
+  );
+}

--- a/app/(main)/admin/inquiries/page.tsx
+++ b/app/(main)/admin/inquiries/page.tsx
@@ -1,0 +1,59 @@
+import { Inbox } from "lucide-react";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { getInquiries } from "@/app/actions/contact/get";
+import { InquiryListView } from "@/components/features/admin/inquiry-list-view";
+import { Separator } from "@/components/ui/separator";
+import { requireAdmin } from "@/lib/auth/admin-guard";
+
+export const metadata: Metadata = {
+  title: "お問い合わせ管理",
+};
+
+type PageProps = {
+  searchParams: Promise<{
+    status?: string;
+    category?: string;
+    page?: string;
+  }>;
+};
+
+export default async function AdminInquiriesPage({ searchParams }: PageProps) {
+  await requireAdmin();
+
+  const params = await searchParams;
+  const { items, totalCount, totalPages, currentPage } = await getInquiries({
+    status: params.status,
+    category: params.category,
+    page: params.page ? Number(params.page) : 1,
+  });
+
+  return (
+    <main className="container mx-auto max-w-6xl px-4 py-8 md:py-12">
+      <div className="space-y-1 mb-6">
+        <div className="flex items-center gap-3">
+          <Inbox className="h-6 w-6 text-muted-foreground" />
+          <h1 className="text-2xl sm:text-3xl font-bold">お問い合わせ管理</h1>
+        </div>
+        <p className="text-muted-foreground">
+          ユーザーからのお問い合わせを管理します
+        </p>
+      </div>
+
+      <Separator className="mb-6" />
+
+      <Suspense
+        fallback={<div className="text-muted-foreground">読込中...</div>}
+      >
+        <InquiryListView
+          items={items}
+          totalCount={totalCount}
+          totalPages={totalPages}
+          currentPage={currentPage}
+          currentStatus={params.status}
+          currentCategory={params.category}
+        />
+      </Suspense>
+    </main>
+  );
+}

--- a/app/actions/contact/get.ts
+++ b/app/actions/contact/get.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { and, count, desc, eq, type SQL } from "drizzle-orm";
+import { db } from "@/db";
+import * as schema from "@/db/schema";
+import { requireAdmin } from "@/lib/auth/admin-guard";
+
+const ITEMS_PER_PAGE = 20;
+
+export type InquiryFilters = {
+  status?: string;
+  category?: string;
+  page?: number;
+};
+
+export async function getInquiries(filters: InquiryFilters = {}) {
+  await requireAdmin();
+
+  const page = Math.max(1, filters.page ?? 1);
+  const offset = (page - 1) * ITEMS_PER_PAGE;
+
+  const conditions: SQL[] = [];
+  if (filters.status) {
+    conditions.push(eq(schema.contactInquiry.status, filters.status));
+  }
+  if (filters.category) {
+    conditions.push(eq(schema.contactInquiry.category, filters.category));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [items, [total]] = await Promise.all([
+    db
+      .select()
+      .from(schema.contactInquiry)
+      .where(where)
+      .orderBy(desc(schema.contactInquiry.createdAt))
+      .limit(ITEMS_PER_PAGE)
+      .offset(offset),
+    db.select({ count: count() }).from(schema.contactInquiry).where(where),
+  ]);
+
+  return {
+    items,
+    totalCount: total?.count ?? 0,
+    totalPages: Math.ceil((total?.count ?? 0) / ITEMS_PER_PAGE),
+    currentPage: page,
+  };
+}
+
+export async function getInquiryById(id: string) {
+  await requireAdmin();
+
+  const [inquiry] = await db
+    .select()
+    .from(schema.contactInquiry)
+    .where(eq(schema.contactInquiry.id, id))
+    .limit(1);
+
+  return inquiry ?? null;
+}

--- a/app/actions/contact/send.test.ts
+++ b/app/actions/contact/send.test.ts
@@ -10,6 +10,19 @@ vi.mock("@/lib/mail/client", () => ({
   },
 }));
 
+// Mock database
+vi.mock("@/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  contactInquiry: {},
+}));
+
 // Mock next/headers
 vi.mock("next/headers", () => ({
   headers: vi
@@ -124,11 +137,28 @@ describe("sendContactMessage", () => {
     expect(result.error).toBe("Bot verification failed");
   });
 
-  it("should handle email send failure gracefully", async () => {
+  it("should handle email send failure gracefully (DB still succeeds)", async () => {
     const { resend } = await import("@/lib/mail/client");
     (resend.emails.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("Send Error"),
     );
+
+    const result = await sendContactMessage({
+      name: "Test User",
+      email: "test@example.com",
+      category: "feature",
+      message: "This is a test message for feature request",
+    });
+
+    // Email failure is non-fatal — DB insert still succeeded
+    expect(result.success).toBe(true);
+  });
+
+  it("should fail when DB insert fails", async () => {
+    const { db } = await import("@/db");
+    (db.insert as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      values: vi.fn().mockRejectedValueOnce(new Error("DB Error")),
+    });
 
     const result = await sendContactMessage({
       name: "Test User",

--- a/app/actions/contact/send.ts
+++ b/app/actions/contact/send.ts
@@ -2,6 +2,8 @@
 
 import { headers } from "next/headers";
 import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema";
 import { resend } from "@/lib/mail/client";
 import { checkRateLimit } from "@/lib/rate-limit";
 
@@ -89,26 +91,39 @@ export async function sendContactMessage(input: ContactInput) {
     "onboarding@resend.dev";
 
   try {
-    await resend.emails.send({
-      from: process.env.EMAIL_FROM || "onboarding@resend.dev",
-      to: notifyTo,
-      replyTo: email,
-      subject: `【AssetLens】お問い合わせ: ${CATEGORY_LABELS[category]}`,
-      html: `
-        <h2>お問い合わせ</h2>
-        <table style="border-collapse:collapse;width:100%">
-          <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">名前</td><td style="padding:8px;border:1px solid #ddd">${sanitize(name)}</td></tr>
-          <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">メール</td><td style="padding:8px;border:1px solid #ddd">${sanitize(email)}</td></tr>
-          <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">カテゴリ</td><td style="padding:8px;border:1px solid #ddd">${CATEGORY_LABELS[category]}</td></tr>
-        </table>
-        <h3>内容</h3>
-        <p style="white-space:pre-wrap">${sanitize(message)}</p>
-      `,
+    // Persist to database first
+    await db.insert(schema.contactInquiry).values({
+      name,
+      email,
+      category,
+      message,
     });
+
+    // Send email notification (non-fatal if fails)
+    try {
+      await resend.emails.send({
+        from: process.env.EMAIL_FROM || "onboarding@resend.dev",
+        to: notifyTo,
+        replyTo: email,
+        subject: `【AssetLens】お問い合わせ: ${CATEGORY_LABELS[category]}`,
+        html: `
+          <h2>お問い合わせ</h2>
+          <table style="border-collapse:collapse;width:100%">
+            <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">名前</td><td style="padding:8px;border:1px solid #ddd">${sanitize(name)}</td></tr>
+            <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">メール</td><td style="padding:8px;border:1px solid #ddd">${sanitize(email)}</td></tr>
+            <tr><td style="padding:8px;border:1px solid #ddd;font-weight:bold">カテゴリ</td><td style="padding:8px;border:1px solid #ddd">${CATEGORY_LABELS[category]}</td></tr>
+          </table>
+          <h3>内容</h3>
+          <p style="white-space:pre-wrap">${sanitize(message)}</p>
+        `,
+      });
+    } catch (emailError) {
+      console.error("[Contact] Email notification failed:", emailError);
+    }
 
     return { success: true };
   } catch (error) {
-    console.error("[Contact] Failed to send:", error);
+    console.error("[Contact] Failed to save inquiry:", error);
     return { success: false, error: "Failed to send message" };
   }
 }

--- a/app/actions/contact/update-status.test.ts
+++ b/app/actions/contact/update-status.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+          limit: vi.fn().mockResolvedValue([{ id: "test-id" }]),
+        }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  contactInquiry: {
+    id: "id",
+    status: "status",
+    category: "category",
+    createdAt: "created_at",
+  },
+}));
+
+vi.mock("@/lib/auth/admin-guard", () => ({
+  requireAdmin: vi.fn().mockResolvedValue({
+    user: { id: "admin-1", email: "admin@test.com", name: "Admin" },
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("updateInquiryStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should reject invalid status", async () => {
+    const { updateInquiryStatus } = await import(
+      "@/app/actions/contact/update-status"
+    );
+    const result = await updateInquiryStatus({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      status: "invalid" as "new",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject invalid UUID", async () => {
+    const { updateInquiryStatus } = await import(
+      "@/app/actions/contact/update-status"
+    );
+    const result = await updateInquiryStatus({
+      id: "not-a-uuid",
+      status: "resolved",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid input", async () => {
+    const { updateInquiryStatus } = await import(
+      "@/app/actions/contact/update-status"
+    );
+    const result = await updateInquiryStatus({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      status: "in_progress",
+      note: "Working on it",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/actions/contact/update-status.ts
+++ b/app/actions/contact/update-status.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db";
+import * as schema from "@/db/schema";
+import { requireAdmin } from "@/lib/auth/admin-guard";
+
+const VALID_STATUSES = ["new", "in_progress", "resolved", "closed"] as const;
+
+const updateSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(VALID_STATUSES),
+  note: z.string().max(2000).optional(),
+});
+
+export type UpdateStatusInput = z.infer<typeof updateSchema>;
+
+export async function updateInquiryStatus(input: UpdateStatusInput) {
+  await requireAdmin();
+
+  const parsed = updateSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const { id, status, note } = parsed.data;
+
+  const [existing] = await db
+    .select({ id: schema.contactInquiry.id })
+    .from(schema.contactInquiry)
+    .where(eq(schema.contactInquiry.id, id))
+    .limit(1);
+
+  if (!existing) {
+    return { success: false, error: "Inquiry not found" };
+  }
+
+  await db
+    .update(schema.contactInquiry)
+    .set({
+      status,
+      ...(note !== undefined ? { note } : {}),
+    })
+    .where(eq(schema.contactInquiry.id, id));
+
+  revalidatePath("/admin/inquiries");
+  revalidatePath(`/admin/inquiries/${id}`);
+
+  return { success: true };
+}

--- a/components/features/admin/inquiry-detail-view.stories.tsx
+++ b/components/features/admin/inquiry-detail-view.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { SelectContactInquiry } from "@/db/schema";
+import { InquiryDetailView } from "./inquiry-detail-view";
+
+const meta: Meta<typeof InquiryDetailView> = {
+  title: "Features/Admin/InquiryDetailView",
+  component: InquiryDetailView,
+  parameters: {
+    nextjs: { appDirectory: true },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InquiryDetailView>;
+
+const mockInquiry: SelectContactInquiry = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  name: "田中太郎",
+  email: "tanaka@example.com",
+  category: "question",
+  message:
+    "パスキーの登録方法がわかりません。\n\n設定画面を開いたのですが、「パスキーを追加」のようなボタンが見当たりませんでした。\n\nブラウザはChrome最新版を使っています。\nOSはWindows 11です。\n\nよろしくお願いいたします。",
+  status: "new",
+  note: null,
+  createdAt: new Date("2026-04-01T10:00:00"),
+  updatedAt: new Date("2026-04-01T10:00:00"),
+};
+
+export const NewInquiry: Story = {
+  args: { inquiry: mockInquiry },
+};
+
+export const InProgressWithNote: Story = {
+  args: {
+    inquiry: {
+      ...mockInquiry,
+      status: "in_progress",
+      note: "パスキー機能はv2.29.0で実装予定。リリース後にフォローアップ予定。",
+    },
+  },
+};
+
+export const Resolved: Story = {
+  args: {
+    inquiry: {
+      ...mockInquiry,
+      status: "resolved",
+      note: "v2.29.0リリースに合わせて通知メール送信済み",
+    },
+  },
+};
+
+export const BugReport: Story = {
+  args: {
+    inquiry: {
+      ...mockInquiry,
+      category: "bug",
+      message:
+        "CSVエクスポートすると文字化けが発生します。\nExcelで開くとShift_JISで読み込まれているようです。\nUTF-8 BOM付きで出力してほしいです。",
+      status: "in_progress",
+      note: "UTF-8 BOM対応のPR作成中",
+    },
+  },
+};

--- a/components/features/admin/inquiry-detail-view.tsx
+++ b/components/features/admin/inquiry-detail-view.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { ArrowLeft, Mail, Save, User } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { updateInquiryStatus } from "@/app/actions/contact/update-status";
+import {
+  CATEGORY_LABELS,
+  InquiryStatusBadge,
+  STATUS_OPTIONS,
+} from "@/components/features/admin/inquiry-status-badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import type { SelectContactInquiry } from "@/db/schema";
+
+interface InquiryDetailViewProps {
+  inquiry: SelectContactInquiry;
+}
+
+export function InquiryDetailView({ inquiry }: InquiryDetailViewProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [status, setStatus] = useState(inquiry.status);
+  const [note, setNote] = useState(inquiry.note ?? "");
+  const [saved, setSaved] = useState(false);
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await updateInquiryStatus({
+        id: inquiry.id,
+        status: status as "new" | "in_progress" | "resolved" | "closed",
+        note: note || undefined,
+      });
+      if (result.success) {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link
+        href="/admin/inquiries"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        一覧に戻る
+      </Link>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        {/* Main content */}
+        <div className="md:col-span-2 space-y-6">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-lg">お問い合わせ内容</CardTitle>
+                <InquiryStatusBadge status={inquiry.status} />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex items-center gap-2">
+                  <User className="h-4 w-4 text-muted-foreground" />
+                  <div>
+                    <p className="text-xs text-muted-foreground">名前</p>
+                    <p className="text-sm font-medium">{inquiry.name}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Mail className="h-4 w-4 text-muted-foreground" />
+                  <div>
+                    <p className="text-xs text-muted-foreground">メール</p>
+                    <a
+                      href={`mailto:${inquiry.email}`}
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      {inquiry.email}
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <p className="text-xs text-muted-foreground mb-1">カテゴリ</p>
+                <p className="text-sm">
+                  {CATEGORY_LABELS[inquiry.category] ?? inquiry.category}
+                </p>
+              </div>
+
+              <Separator />
+
+              <div>
+                <p className="text-xs text-muted-foreground mb-2">メッセージ</p>
+                <div className="rounded-md bg-muted/50 p-4 text-sm whitespace-pre-wrap leading-relaxed">
+                  {inquiry.message}
+                </div>
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                受信日時:{" "}
+                {format(new Date(inquiry.createdAt), "yyyy/MM/dd HH:mm", {
+                  locale: ja,
+                })}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar: Status & Note */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">ステータス管理</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label
+                  htmlFor="inquiry-status"
+                  className="text-sm font-medium mb-1.5 block"
+                >
+                  ステータス
+                </label>
+                <Select value={status} onValueChange={setStatus}>
+                  <SelectTrigger id="inquiry-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUS_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="inquiry-note"
+                  className="text-sm font-medium mb-1.5 block"
+                >
+                  管理メモ
+                </label>
+                <Textarea
+                  id="inquiry-note"
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder="対応メモを記入..."
+                  rows={4}
+                  maxLength={2000}
+                />
+              </div>
+
+              <Button
+                onClick={handleSave}
+                disabled={isPending}
+                className="w-full"
+              >
+                <Save className="h-4 w-4 mr-2" />
+                {saved ? "保存しました ✓" : isPending ? "保存中..." : "保存"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/admin/inquiry-list-view.stories.tsx
+++ b/components/features/admin/inquiry-list-view.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { SelectContactInquiry } from "@/db/schema";
+import { InquiryListView } from "./inquiry-list-view";
+
+const meta: Meta<typeof InquiryListView> = {
+  title: "Features/Admin/InquiryListView",
+  component: InquiryListView,
+  parameters: {
+    nextjs: { appDirectory: true },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InquiryListView>;
+
+const mockItems: SelectContactInquiry[] = [
+  {
+    id: "1",
+    name: "田中太郎",
+    email: "tanaka@example.com",
+    category: "question",
+    message:
+      "パスキーの登録方法がわかりません。設定画面にボタンが見つかりませんでした。",
+    status: "new",
+    note: null,
+    createdAt: new Date("2026-04-01T10:00:00"),
+    updatedAt: new Date("2026-04-01T10:00:00"),
+  },
+  {
+    id: "2",
+    name: "佐藤花子",
+    email: "sato@example.com",
+    category: "bug",
+    message:
+      "CSVエクスポートすると文字化けが発生します。UTF-8で出力してほしいです。",
+    status: "in_progress",
+    note: "Investigating encoding issue",
+    createdAt: new Date("2026-03-30T14:30:00"),
+    updatedAt: new Date("2026-03-31T09:00:00"),
+  },
+  {
+    id: "3",
+    name: "鈴木一郎",
+    email: "suzuki@example.com",
+    category: "feature",
+    message: "月別の予算だけでなく、週別の予算設定もできるようにしてほしい。",
+    status: "resolved",
+    note: "Added to backlog",
+    createdAt: new Date("2026-03-28T08:00:00"),
+    updatedAt: new Date("2026-03-29T16:00:00"),
+  },
+  {
+    id: "4",
+    name: "山田二郎",
+    email: "yamada@example.com",
+    category: "other",
+    message: "素晴らしいアプリですね！これからも応援しています。",
+    status: "closed",
+    note: null,
+    createdAt: new Date("2026-03-25T12:00:00"),
+    updatedAt: new Date("2026-03-25T12:00:00"),
+  },
+];
+
+export const Default: Story = {
+  args: {
+    items: mockItems,
+    totalCount: 4,
+    totalPages: 1,
+    currentPage: 1,
+  },
+};
+
+export const WithPagination: Story = {
+  args: {
+    items: mockItems,
+    totalCount: 45,
+    totalPages: 3,
+    currentPage: 2,
+  },
+};
+
+export const Filtered: Story = {
+  args: {
+    items: mockItems.filter((i) => i.status === "new"),
+    totalCount: 1,
+    totalPages: 1,
+    currentPage: 1,
+    currentStatus: "new",
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    totalCount: 0,
+    totalPages: 0,
+    currentPage: 1,
+  },
+};
+
+export const EmptyFiltered: Story = {
+  args: {
+    items: [],
+    totalCount: 0,
+    totalPages: 0,
+    currentPage: 1,
+    currentStatus: "resolved",
+  },
+};

--- a/components/features/admin/inquiry-list-view.tsx
+++ b/components/features/admin/inquiry-list-view.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
+import { Inbox, Search } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import {
+  CATEGORY_LABELS,
+  InquiryStatusBadge,
+  STATUS_OPTIONS,
+} from "@/components/features/admin/inquiry-status-badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { SelectContactInquiry } from "@/db/schema";
+
+interface InquiryListViewProps {
+  items: SelectContactInquiry[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+  currentStatus?: string;
+  currentCategory?: string;
+}
+
+export function InquiryListView({
+  items,
+  totalCount,
+  totalPages,
+  currentPage,
+  currentStatus,
+  currentCategory,
+}: InquiryListViewProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const updateFilter = useCallback(
+    (key: string, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value && value !== "all") {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      params.delete("page");
+      router.push(`/admin/inquiries?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  const goToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page > 1) {
+        params.set("page", String(page));
+      } else {
+        params.delete("page");
+      }
+      router.push(`/admin/inquiries?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Select
+          value={currentStatus ?? "all"}
+          onValueChange={(v) => updateFilter("status", v)}
+        >
+          <SelectTrigger className="w-36" aria-label="Filter by status">
+            <SelectValue placeholder="ステータス" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべて</SelectItem>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={currentCategory ?? "all"}
+          onValueChange={(v) => updateFilter("category", v)}
+        >
+          <SelectTrigger className="w-36" aria-label="Filter by category">
+            <SelectValue placeholder="カテゴリ" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべて</SelectItem>
+            {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <span className="text-sm text-muted-foreground ml-auto">
+          {totalCount}件
+        </span>
+      </div>
+
+      {/* Table */}
+      {items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          {currentStatus || currentCategory ? (
+            <>
+              <Search className="h-10 w-10 mb-3 opacity-50" />
+              <p className="text-sm">条件に一致するお問い合わせがありません</p>
+            </>
+          ) : (
+            <>
+              <Inbox className="h-10 w-10 mb-3 opacity-50" />
+              <p className="text-sm">お問い合わせはまだありません</p>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-24">ステータス</TableHead>
+                <TableHead className="w-24">カテゴリ</TableHead>
+                <TableHead>名前</TableHead>
+                <TableHead className="hidden sm:table-cell">メール</TableHead>
+                <TableHead className="hidden md:table-cell">
+                  メッセージ
+                </TableHead>
+                <TableHead className="w-28">日時</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((inquiry) => (
+                <TableRow key={inquiry.id} className="cursor-pointer">
+                  <TableCell>
+                    <Link href={`/admin/inquiries/${inquiry.id}`}>
+                      <InquiryStatusBadge status={inquiry.status} />
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/admin/inquiries/${inquiry.id}`}
+                      className="text-sm"
+                    >
+                      {CATEGORY_LABELS[inquiry.category] ?? inquiry.category}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/admin/inquiries/${inquiry.id}`}
+                      className="font-medium"
+                    >
+                      {inquiry.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell">
+                    <Link
+                      href={`/admin/inquiries/${inquiry.id}`}
+                      className="text-sm text-muted-foreground"
+                    >
+                      {inquiry.email}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell max-w-xs">
+                    <Link
+                      href={`/admin/inquiries/${inquiry.id}`}
+                      className="text-sm text-muted-foreground truncate block"
+                    >
+                      {inquiry.message.slice(0, 60)}
+                      {inquiry.message.length > 60 ? "…" : ""}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/admin/inquiries/${inquiry.id}`}
+                      className="text-xs text-muted-foreground whitespace-nowrap"
+                    >
+                      {formatDistanceToNow(new Date(inquiry.createdAt), {
+                        addSuffix: true,
+                        locale: ja,
+                      })}
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToPage(currentPage - 1)}
+            disabled={currentPage <= 1}
+          >
+            前へ
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {currentPage} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToPage(currentPage + 1)}
+            disabled={currentPage >= totalPages}
+          >
+            次へ
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/admin/inquiry-status-badge.stories.tsx
+++ b/components/features/admin/inquiry-status-badge.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InquiryStatusBadge } from "./inquiry-status-badge";
+
+const meta: Meta<typeof InquiryStatusBadge> = {
+  title: "Features/Admin/InquiryStatusBadge",
+  component: InquiryStatusBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InquiryStatusBadge>;
+
+export const New: Story = { args: { status: "new" } };
+export const InProgress: Story = { args: { status: "in_progress" } };
+export const Resolved: Story = { args: { status: "resolved" } };
+export const Closed: Story = { args: { status: "closed" } };
+export const Unknown: Story = { args: { status: "unknown" } };

--- a/components/features/admin/inquiry-status-badge.tsx
+++ b/components/features/admin/inquiry-status-badge.tsx
@@ -1,0 +1,55 @@
+import { cn } from "@/lib/utils";
+
+const STATUS_CONFIG = {
+  new: {
+    label: "新規",
+    className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  },
+  in_progress: {
+    label: "対応中",
+    className:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  },
+  resolved: {
+    label: "解決済み",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  closed: {
+    label: "クローズ",
+    className:
+      "bg-gray-100 text-gray-800 dark:bg-gray-800/50 dark:text-gray-400",
+  },
+} as const;
+
+type InquiryStatus = keyof typeof STATUS_CONFIG;
+
+interface InquiryStatusBadgeProps {
+  status: string;
+}
+
+export function InquiryStatusBadge({ status }: InquiryStatusBadgeProps) {
+  const config = STATUS_CONFIG[status as InquiryStatus] ?? STATUS_CONFIG.new;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap",
+        config.className,
+      )}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  question: "質問",
+  bug: "バグ報告",
+  feature: "機能要望",
+  other: "その他",
+};
+
+export const STATUS_OPTIONS = Object.entries(STATUS_CONFIG).map(
+  ([value, { label }]) => ({ value, label }),
+);

--- a/components/layouts/site-header.tsx
+++ b/components/layouts/site-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogIn, LogOut, Settings, User, Wallet } from "lucide-react";
+import { Inbox, LogIn, LogOut, Settings, User, Wallet } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -132,6 +132,12 @@ export function SiteHeader() {
                   <Link href="/profile" className="cursor-pointer">
                     <User className="mr-2 h-4 w-4" />
                     プロフィール
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/admin/inquiries" className="cursor-pointer">
+                    <Inbox className="mr-2 h-4 w-4" />
+                    お問い合わせ管理
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -420,3 +420,30 @@ export const dismissedDuplicateRelations = relations(
     }),
   }),
 );
+
+export const contactInquiry = pgTable(
+  "contact_inquiry",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull(),
+    category: text("category").notNull(),
+    message: text("message").notNull(),
+    status: text("status").default("new").notNull(),
+    note: text("note"),
+    createdAt: timestamp("created_at", { precision: 0, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { precision: 0, withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("contact_inquiry_status_idx").on(table.status),
+    index("contact_inquiry_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export type SelectContactInquiry = InferSelectModel<typeof contactInquiry>;
+export type InsertContactInquiry = InferInsertModel<typeof contactInquiry>;

--- a/drizzle/0015_graceful_masque.sql
+++ b/drizzle/0015_graceful_masque.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "contact_inquiry" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"category" text NOT NULL,
+	"message" text NOT NULL,
+	"status" text DEFAULT 'new' NOT NULL,
+	"note" text,
+	"created_at" timestamp (0) with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "contact_inquiry_status_idx" ON "contact_inquiry" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "contact_inquiry_created_at_idx" ON "contact_inquiry" USING btree ("created_at");

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1392 @@
+{
+  "id": "4ffa5be3-0ea8-4daa-b4bf-006ae6560ce8",
+  "prevId": "997c5df6-08f0-47ec-8ab3-5f911cb69cbb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget": {
+      "name": "budget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "budget_userId_categoryId_idx": {
+          "name": "budget_userId_categoryId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "budget_user_id_user_id_fk": {
+          "name": "budget_user_id_user_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "budget_category_id_category_id_fk": {
+          "name": "budget_category_id_category_id_fk",
+          "tableFrom": "budget",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'expense'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "category_userId_idx": {
+          "name": "category_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_userId_user_id_fk": {
+          "name": "category_userId_user_id_fk",
+          "tableFrom": "category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_inquiry": {
+      "name": "contact_inquiry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_inquiry_status_idx": {
+          "name": "contact_inquiry_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_inquiry_created_at_idx": {
+          "name": "contact_inquiry_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_duplicate": {
+      "name": "dismissed_duplicate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id_1": {
+          "name": "transaction_id_1",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id_2": {
+          "name": "transaction_id_2",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_dup_userId_idx": {
+          "name": "dismissed_dup_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_dup_pair_idx": {
+          "name": "dismissed_dup_pair_idx",
+          "columns": [
+            {
+              "expression": "transaction_id_1",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_id_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_duplicate_user_id_user_id_fk": {
+          "name": "dismissed_duplicate_user_id_user_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dismissed_duplicate_transaction_id_1_transaction_id_fk": {
+          "name": "dismissed_duplicate_transaction_id_1_transaction_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "transaction",
+          "columnsFrom": [
+            "transaction_id_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dismissed_duplicate_transaction_id_2_transaction_id_fk": {
+          "name": "dismissed_duplicate_transaction_id_2_transaction_id_fk",
+          "tableFrom": "dismissed_duplicate",
+          "tableTo": "transaction",
+          "columnsFrom": [
+            "transaction_id_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store": {
+      "name": "store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_userId_idx": {
+          "name": "store_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JPY'"
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_payment_date": {
+          "name": "next_payment_date",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_userId_idx": {
+          "name": "subscription_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_userId_idx": {
+          "name": "transactions_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_date_idx": {
+          "name": "transactions_userId_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_userId_storeName_idx": {
+          "name": "transactions_userId_storeName_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_user_id_user_id_fk": {
+          "name": "transaction_user_id_user_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_category_id_category_id_fk": {
+          "name": "transaction_category_id_category_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_template": {
+      "name": "transaction_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_expense": {
+          "name": "is_expense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_template_user_id_user_id_fk": {
+          "name": "transaction_template_user_id_user_id_fk",
+          "tableFrom": "transaction_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775107658426,
       "tag": "0014_absurd_gladiator",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775135744418,
+      "tag": "0015_graceful_masque",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/auth/admin-guard.ts
+++ b/lib/auth/admin-guard.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+
+const getAdminEmails = () =>
+  (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+export async function requireAdmin() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(session.user.email.toLowerCase())) {
+    redirect("/dashboard");
+  }
+
+  return session;
+}
+
+export async function isAdmin(email: string): Promise<boolean> {
+  const adminEmails = getAdminEmails();
+  return adminEmails.includes(email.toLowerCase());
+}


### PR DESCRIPTION
## Overview

Adds an admin dashboard for managing contact form submissions. Inquiries are now stored in the database alongside email notifications, enabling status tracking and triage.

Relates to #241

## Changes

### Database
- New `contact_inquiry` table with status tracking, indexes on `status` and `created_at`
- Migration: `drizzle/0015_graceful_masque.sql`

### Server Actions
- **`send.ts`** (modified): Dual-write — DB insert + email notification (email is non-fatal)
- **`get.ts`** (new): Paginated list with status/category filters + detail by ID
- **`update-status.ts`** (new): Status transitions with optional admin note

### Admin UI
- **`/admin/inquiries`**: Filterable table with status badges, pagination
- **`/admin/inquiries/[id]`**: Detail view with status management sidebar
- Components: `InquiryStatusBadge`, `InquiryListView`, `InquiryDetailView`
- Navigation: Admin link added to user dropdown menu

### Access Control
- `requireAdmin()` guard using `ADMIN_EMAILS` env var
- Non-admin users redirected to dashboard

### Tests
- 357/357 unit tests passing (10 new: send + update-status)
- 5 Storybook stories covering all admin components